### PR TITLE
docs: add display scale strategy article

### DIFF
--- a/.claude/skills/css-wisdom/descriptions.json
+++ b/.claude/skills/css-wisdom/descriptions.json
@@ -74,6 +74,7 @@
   "methodology/design-systems/tight-token-strategy/token-preview.mdx": "Visual reference of all available tokens",
   "methodology/design-systems/tight-token-strategy/component-tokens.mdx": "System tokens vs arbitrary values decision framework",
   "methodology/design-systems/two-tier-size-strategy.mdx": "Two-tier sizing: base + scale for consistent spacing/typography",
+  "methodology/design-systems/display-scale-strategy.mdx": "Custom --display-scale CSS property for desktop app zoom (Tauri/Electron), token-based scaling",
   "typography/font-sizing/three-tier-font-size-strategy.mdx": "Three-tier font-size architecture: base, scale, component",
   "typography/text-effects/text-outline-and-stroke.mdx": "Text outline/stroke (縁取り): -webkit-text-stroke, text-shadow hack, SVG stroke, feMorphology, paint-order"
 }

--- a/src/content/docs-ja/methodology/design-systems/display-scale-strategy.mdx
+++ b/src/content/docs-ja/methodology/design-systems/display-scale-strategy.mdx
@@ -1,0 +1,439 @@
+---
+title: ディスプレイスケール戦略
+sidebar_position: 4
+---
+
+import CssPreview from '@/components/CssPreview';
+
+## 問題
+
+Web 技術で構築されたデスクトップアプリ（Tauri、Electron）は、WebView 内でレンダリングされます。ユーザーはネイティブアプリと同じズーム操作を期待します：Ctrl+スクロールや Ctrl+/- で UI 全体を拡大縮小する機能です。
+
+明白なアプローチはブラウザのネイティブズームを使うことですが、WebView 環境ではネイティブズームは問題を引き起こします：
+
+- **カーソル位置のずれ** — 100% 以外のズームでは、WebView が報告するカーソル位置が実際の画面位置からずれる。ドラッグハンドル、リサイズパネル、クリックターゲットが不整合になる
+- **制御できないスケーリング** — ネイティブズームは*すべて*を均一にスケーリングする。どのスケールでもシャープであるべきヘアラインボーダーやボーダーラディウスの値も含めて
+- **永続化 API がない** — WebView API でズームレベルをセッション間で保存・復元する標準的な方法がない
+
+結果：ユーザーがズームインすると、パネルがドラッグできなくなり、ボタンがクリックできなくなり、アプリの再起動でズームがリセットされます。ユーザビリティを向上させるはずの機能が、アプリを壊れたように感じさせてしまいます。
+
+### なぜ `transform: scale()` ではダメなのか
+
+次に思いつくのは、アプリのルート要素を `transform: scale()` でラップすることです：
+
+```css
+#app-root {
+  transform: scale(var(--zoom));
+  transform-origin: top left;
+}
+```
+
+これはカーソル位置のずれを回避しますが、新たな問題を生みます：
+
+- 要素のレイアウトサイズが変わらない — 拡大されたアプリがコンテナからはみ出す
+- transform された祖先要素の中で fixed/sticky ポジショニングが壊れる
+- 非整数のスケールファクターでテキストがぼやける
+- コンテナに逆数の寸法を計算して適用する必要がある
+
+ネイティブズームも transform スケールも、UI を*外側から*スケーリングしようとしています。ディスプレイスケール戦略は*内側から*スケーリングします。
+
+## 解決方法
+
+ブラウザのズームを単一の CSS カスタムプロパティ — `--display-scale` — に置き換え、すべてのデザイントークンにそれを掛け合わせます：
+
+```css
+:root {
+  --display-scale: 1; /* default: 100% */
+}
+```
+
+ズームに連動すべきすべてのトークンが `calc()` を使います：
+
+```css
+:root {
+  --spacing-md: calc(8px * var(--display-scale));
+  --spacing-lg: calc(12px * var(--display-scale));
+  --font-size-base: calc(14px * var(--display-scale));
+  --toolbar-height: calc(52px * var(--display-scale));
+}
+```
+
+`--display-scale` が `1` から `1.25` に変わると、すべての値が即座に再計算されます。8px のギャップは 10px に、14px のフォントは 17.5px に、ツールバーは 52px から 65px に拡大します。UI 全体が単一の CSS リフローでスムーズかつ比例的にスケーリングされます。JavaScript によるレイアウト再計算は不要です。
+
+### スケールステップの定義
+
+連続的なスケーリングよりも離散的なステップのほうが適しています。事前定義されたセットにより、中途半端なサイズを防ぎ、機能の挙動を予測可能にします：
+
+```typescript
+const VALID_SCALES = [0.75, 0.9, 1.0, 1.1, 1.25, 1.5, 1.75, 2.0];
+```
+
+ズームイン・アウトでこれらのステップを順に切り替えます。ユーザーは設定画面やキーボードショートカットでスケールを選択し、アプリは選択を永続化して起動時に適用します。
+
+### スケールの適用
+
+JavaScript 側の処理は最小限です。ルート要素に CSS プロパティを1つ設定するだけです：
+
+```typescript
+function applyDisplayScale(scale: number): void {
+  document.documentElement.style.setProperty(
+    "--display-scale",
+    String(scale)
+  );
+}
+```
+
+ネイティブズームが干渉しないよう、デフォルトのズームジェスチャーをインターセプトします：
+
+```typescript
+// Prevent native zoom, dispatch custom events instead
+window.addEventListener("wheel", (e) => {
+  if (e.ctrlKey) {
+    e.preventDefault();
+    dispatchScaleChange(e.deltaY > 0 ? "out" : "in");
+  }
+}, { passive: false });
+```
+
+カスタムイベントがスケールステップのロジックをトリガーし、新しい値を永続化して `applyDisplayScale()` を呼び出します。残りは CSS が処理します。
+
+## トークンアーキテクチャ
+
+重要なデザイン判断は**何をスケーリングし、何をスケーリングしないか**です。
+
+### スケーリングする値
+
+ユーザーが「UI」として認識するものはすべてスケーリングすべきです：
+
+| カテゴリ | 例 | 計算式 |
+| --- | --- | --- |
+| スペーシング | padding、margin、gap | `calc(Npx * var(--display-scale))` |
+| フォントサイズ | 本文、見出し、ラベル | `calc(Npx * var(--display-scale))` |
+| アイコンサイズ | ツールバーアイコン、ステータスアイコン | `calc(Npx * var(--display-scale))` |
+| コンポーネントサイズ | ボタン、チェックボックス、ツールバーの高さ | `calc(Npx * var(--display-scale))` |
+
+### 固定のままにする値
+
+スケールに関係なく一定であるべき値もあります：
+
+| カテゴリ | 固定にする理由 | 例 |
+| --- | --- | --- |
+| 1px ヘアライン | 区切り線やセパレーターはシャープなままであるべき | `--spacing-1px: 1px` |
+| ボーダーラディウス | 角丸はスタイルの選択であり、サイズではない | `--radius-md: 4px` |
+| ボーダー幅 | 細いボーダーはどのスケールでも明瞭さを保つ | `border: 1px solid` |
+| オーバーレイの不透明度 | 暗くする効果はサイズではなく知覚に基づく | `rgba(0, 0, 0, 0.6)` |
+
+判断基準：その値が**どれくらい大きいか**を定義しているならスケーリングする。**どう見えるか**（角丸、ボーダー、不透明度）を定義しているなら固定のままにする。
+
+## デモ
+
+### スケーリングされたトークン vs 固定トークン
+
+このデモは同じ UI を3つの異なるディスプレイスケールで表示しています。スペーシング、テキスト、アイコンが比例的にスケーリングされる一方、ボーダーやボーダーラディウスは固定のままであることに注目してください。
+
+<CssPreview client:load
+  title="Display Scale: 75%, 100%, 125%"
+  height={380}
+  html={`    <div class="scale-demo">
+      <div class="scale-demo__col" style="--ds: 0.75">
+        <div class="scale-demo__badge">75%</div>
+        <div class="scale-demo__card">
+          <div class="scale-demo__toolbar">
+            <div class="scale-demo__icon"></div>
+            <div class="scale-demo__icon"></div>
+            <div class="scale-demo__icon"></div>
+          </div>
+          <div class="scale-demo__body">
+            <div class="scale-demo__title">Document Title</div>
+            <div class="scale-demo__text">Body text scales with the display factor. Borders stay thin.</div>
+          </div>
+          <div class="scale-demo__footer">
+            <button class="scale-demo__btn">Save</button>
+          </div>
+        </div>
+      </div>
+      <div class="scale-demo__col" style="--ds: 1.0">
+        <div class="scale-demo__badge">100%</div>
+        <div class="scale-demo__card">
+          <div class="scale-demo__toolbar">
+            <div class="scale-demo__icon"></div>
+            <div class="scale-demo__icon"></div>
+            <div class="scale-demo__icon"></div>
+          </div>
+          <div class="scale-demo__body">
+            <div class="scale-demo__title">Document Title</div>
+            <div class="scale-demo__text">Body text scales with the display factor. Borders stay thin.</div>
+          </div>
+          <div class="scale-demo__footer">
+            <button class="scale-demo__btn">Save</button>
+          </div>
+        </div>
+      </div>
+      <div class="scale-demo__col" style="--ds: 1.25">
+        <div class="scale-demo__badge">125%</div>
+        <div class="scale-demo__card">
+          <div class="scale-demo__toolbar">
+            <div class="scale-demo__icon"></div>
+            <div class="scale-demo__icon"></div>
+            <div class="scale-demo__icon"></div>
+          </div>
+          <div class="scale-demo__body">
+            <div class="scale-demo__title">Document Title</div>
+            <div class="scale-demo__text">Body text scales with the display factor. Borders stay thin.</div>
+          </div>
+          <div class="scale-demo__footer">
+            <button class="scale-demo__btn">Save</button>
+          </div>
+        </div>
+      </div>
+    </div>`}
+  css={`.scale-demo {
+      display: grid;
+      grid-template-columns: 1fr 1fr 1fr;
+      gap: 12px;
+      padding: 1rem;
+      font-family: system-ui, sans-serif;
+      color: hsl(222 47% 11%);
+      align-items: start;
+    }
+    .scale-demo__col {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      align-items: center;
+    }
+    .scale-demo__badge {
+      font-size: 0.65rem;
+      font-weight: 700;
+      color: hsl(221 83% 53%);
+      background: hsl(210 40% 96%);
+      padding: 2px 8px;
+      border-radius: 10px;
+    }
+    .scale-demo__card {
+      background: hsl(230 15% 18%);
+      border: 1px solid hsl(230 15% 28%);
+      border-radius: 4px;
+      overflow: hidden;
+      width: 100%;
+    }
+    .scale-demo__toolbar {
+      display: flex;
+      gap: calc(6px * var(--ds));
+      padding: calc(6px * var(--ds)) calc(8px * var(--ds));
+      border-bottom: 1px solid hsl(230 15% 28%);
+      background: hsl(230 15% 15%);
+    }
+    .scale-demo__icon {
+      width: calc(16px * var(--ds));
+      height: calc(16px * var(--ds));
+      background: hsl(215 16% 55%);
+      border-radius: 3px;
+    }
+    .scale-demo__body {
+      padding: calc(8px * var(--ds)) calc(10px * var(--ds));
+      display: flex;
+      flex-direction: column;
+      gap: calc(4px * var(--ds));
+    }
+    .scale-demo__title {
+      font-size: calc(13px * var(--ds));
+      font-weight: 600;
+      color: hsl(0 0% 93%);
+    }
+    .scale-demo__text {
+      font-size: calc(11px * var(--ds));
+      color: hsl(215 16% 65%);
+      line-height: 1.4;
+    }
+    .scale-demo__footer {
+      padding: calc(6px * var(--ds)) calc(10px * var(--ds));
+      border-top: 1px solid hsl(230 15% 28%);
+      display: flex;
+      justify-content: flex-end;
+    }
+    .scale-demo__btn {
+      font-size: calc(11px * var(--ds));
+      padding: calc(3px * var(--ds)) calc(10px * var(--ds));
+      background: hsl(221 83% 53%);
+      color: hsl(0 0% 100%);
+      border: none;
+      border-radius: 3px;
+      cursor: pointer;
+      font-weight: 600;
+    }`} />
+
+### 固定値 vs スケーリング値
+
+このデモは、スケーリングされる値と固定のままの値の違いを示しています。ボーダー、ボーダーラディウス、区切り線の太さは一定のまま — コンテンツの寸法だけが変わります。
+
+<CssPreview client:load
+  title="What Scales vs What Stays Fixed"
+  height={300}
+  html={`    <div class="fixed-demo">
+      <div class="fixed-demo__section">
+        <div class="fixed-demo__label">--display-scale でスケーリングされる値</div>
+        <div class="fixed-demo__items">
+          <div class="fixed-demo__item">
+            <div class="fixed-demo__bar" style="width: 40px; height: 8px; background: hsl(221 83% 53%)"></div>
+            <span>spacing (8px → 10px → 12px)</span>
+          </div>
+          <div class="fixed-demo__item">
+            <span style="font-size: 11px; font-weight: 600">Aa</span>
+            <span>font-size (14px → 17.5px → 21px)</span>
+          </div>
+          <div class="fixed-demo__item">
+            <div class="fixed-demo__bar" style="width: 16px; height: 16px; background: hsl(142 50% 40%); border-radius: 3px"></div>
+            <span>icon size (16px → 20px → 24px)</span>
+          </div>
+          <div class="fixed-demo__item">
+            <div class="fixed-demo__bar" style="width: 60px; height: 12px; background: hsl(262 50% 55%); border-radius: 3px"></div>
+            <span>button/toolbar height</span>
+          </div>
+        </div>
+      </div>
+      <div class="fixed-demo__section">
+        <div class="fixed-demo__label fixed-demo__label--fixed">固定のままの値（スケーリングされない）</div>
+        <div class="fixed-demo__items">
+          <div class="fixed-demo__item">
+            <div class="fixed-demo__bar" style="width: 40px; height: 1px; background: hsl(215 16% 55%)"></div>
+            <span>1px 区切り線 — 常にシャープ</span>
+          </div>
+          <div class="fixed-demo__item">
+            <div class="fixed-demo__bar" style="width: 20px; height: 20px; border: 1px solid hsl(215 16% 55%); border-radius: 4px"></div>
+            <span>border-radius — サイズではなくスタイル</span>
+          </div>
+          <div class="fixed-demo__item">
+            <div class="fixed-demo__bar" style="width: 20px; height: 20px; border: 1px solid hsl(215 16% 55%)"></div>
+            <span>border-width — 細いまま維持</span>
+          </div>
+          <div class="fixed-demo__item">
+            <div class="fixed-demo__bar" style="width: 40px; height: 20px; background: hsla(0, 0%, 0%, 0.5); border-radius: 3px"></div>
+            <span>overlay opacity — 知覚に基づく</span>
+          </div>
+        </div>
+      </div>
+    </div>`}
+  css={`.fixed-demo {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+      padding: 1rem;
+      font-family: system-ui, sans-serif;
+      color: hsl(222 47% 11%);
+    }
+    .fixed-demo__section {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+    .fixed-demo__label {
+      font-size: 0.7rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: hsl(221 83% 53%);
+    }
+    .fixed-demo__label--fixed {
+      color: hsl(215 16% 47%);
+    }
+    .fixed-demo__items {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+    .fixed-demo__item {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      font-size: 0.68rem;
+      color: hsl(215 25% 35%);
+    }
+    .fixed-demo__bar {
+      flex-shrink: 0;
+    }`} />
+
+## Tailwind v4 との統合
+
+[タイトトークン戦略](./tight-token-strategy/)を使う Tailwind v4 プロジェクトでは、`@theme` でベース値を宣言し、`:root` でスケーリングされた値でオーバーライドします：
+
+```css
+/* tokens.css */
+@theme {
+  /* Base values — used by Tailwind for class generation */
+  --spacing-sm: 6px;
+  --spacing-md: 8px;
+  --spacing-lg: 12px;
+  --spacing-xl: 16px;
+
+  --font-size-sm: 12px;
+  --font-size-base: 14px;
+  --font-size-lg: 16px;
+
+  --spacing-icon-sm: 12px;
+  --spacing-icon-md: 16px;
+  --spacing-icon-lg: 20px;
+}
+
+:root {
+  --display-scale: 1;
+
+  /* Runtime overrides — multiply by display-scale */
+  --spacing-sm: calc(6px * var(--display-scale));
+  --spacing-md: calc(8px * var(--display-scale));
+  --spacing-lg: calc(12px * var(--display-scale));
+  --spacing-xl: calc(16px * var(--display-scale));
+
+  --font-size-sm: calc(12px * var(--display-scale));
+  --font-size-base: calc(14px * var(--display-scale));
+  --font-size-lg: calc(16px * var(--display-scale));
+
+  --spacing-icon-sm: calc(12px * var(--display-scale));
+  --spacing-icon-md: calc(16px * var(--display-scale));
+  --spacing-icon-lg: calc(20px * var(--display-scale));
+}
+```
+
+`@theme` ブロックは Tailwind がクラス生成に必要なベース値を提供します。`:root` ブロックはそれらをランタイムでスケーリングされたバージョンでオーバーライドします。`p-lg`、`text-base`、`w-icon-md` などの Tailwind クラスは自動的にスケーリングされた値を使用します。コンポーネントコードの変更は不要です。
+
+### 一回限りのスケーリング値
+
+トークンセットにないコンポーネント固有の寸法には、任意の値で `calc()` を直接使います：
+
+```html
+<!-- Scaled arbitrary value -->
+<div class="w-[calc(240px*var(--display-scale))]">Sidebar</div>
+
+<!-- Or define a component token -->
+<style>
+  .sidebar { width: calc(240px * var(--display-scale)); }
+</style>
+```
+
+## よくある間違い
+
+- **ボーダーラディウスをスケーリングする** — 4px の角丸はどのスケールでも適切に見える。125% で 5px にスケーリングしても価値はなく、異なるスケールの要素を比較したときに不整合が生じる
+- **1px ボーダーをスケーリングする** — ヘアラインボーダーは非整数スケールでぼやける。1px のままにすることで視覚的な明瞭さを維持する
+- **ネイティブズームの防止を忘れる** — Ctrl+スクロールや Ctrl+/- をインターセプトしないと、ネイティブズームとカスタムスケールの両方がトリガーされ、二重スケーリングになる
+- **連続的なスケールを使う** — 自由形式のスケール値（例：1.137）はピクセル丸めのアーティファクトを生む。代わりに事前定義されたステップセットを使う
+- **スケーリングされた値とされていない値を混在させる** — 1つのコンポーネントで `var(--spacing-lg)` の代わりに `gap: 12px` を使うと一貫性が崩れる。ディスプレイスケールを採用したら、*すべての*スペーシングがシステムを通る必要がある
+- **`transform: scale()` でスケーリングする** — 要素のレイアウトサイズが変わらず、fixed/sticky ポジショニングが壊れ、テキストがぼやける。トークンベースのスケーリングの代替にはならない
+
+## いつ使うか
+
+- **デスクトップ Web アプリ** — Tauri、Electron、またはユーザーがズーム機能を期待する WebView ベースのデスクトップアプリケーション
+- **ドラッグ・リサイズ操作のあるアプリ** — ネイティブズームはドラッグハンドル、パネルリサイザー、キャンバス操作のカーソル位置を壊す
+- **タイトトークンを持つデザインシステム** — すべての値が CSS カスタムプロパティを通っていれば、ディスプレイスケールは自然に統合される
+- **UI 密度をユーザーが設定できるアプリ** — 同じメカニズムがアクセシビリティズーム、コンパクトモード、大きなテキストモードをサポートする
+
+### 使わないほうがよい場合
+
+- **通常のブラウザで表示される Web サイト** — 標準的な Web コンテキストではブラウザのズームが正しく動作する。カスタムズームを追加すると体験が悪化する
+- **静的コンテンツサイト** — ブログ、ドキュメント、マーケティングページにはドラッグ操作がなく、ネイティブズーム＋レスポンシブデザインの恩恵を受ける
+- **全体的に `rem` を使っているアプリ** — すべての値が `rem` ベースなら、ルートの `font-size` を変更することでより簡単に同様の効果を得られる
+
+## 参考資料
+
+- [CSS `calc()` — MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/calc)
+- [CSS Custom Properties — MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties)
+- [Tauri WebView2 Zoom Behavior](https://tauri.app/)

--- a/src/content/docs-ja/methodology/design-systems/display-scale-strategy.mdx
+++ b/src/content/docs-ja/methodology/design-systems/display-scale-strategy.mdx
@@ -203,7 +203,7 @@ window.addEventListener("wheel", (e) => {
       align-items: center;
     }
     .scale-demo__badge {
-      font-size: 0.65rem;
+      font-size: 0.75rem;
       font-weight: 700;
       color: hsl(221 83% 53%);
       background: hsl(210 40% 96%);
@@ -272,7 +272,7 @@ window.addEventListener("wheel", (e) => {
   height={300}
   html={`    <div class="fixed-demo">
       <div class="fixed-demo__section">
-        <div class="fixed-demo__label">--display-scale でスケーリングされる値</div>
+        <div class="fixed-demo__label">Scales with --display-scale</div>
         <div class="fixed-demo__items">
           <div class="fixed-demo__item">
             <div class="fixed-demo__bar" style="width: 40px; height: 8px; background: hsl(221 83% 53%)"></div>
@@ -293,23 +293,23 @@ window.addEventListener("wheel", (e) => {
         </div>
       </div>
       <div class="fixed-demo__section">
-        <div class="fixed-demo__label fixed-demo__label--fixed">固定のままの値（スケーリングされない）</div>
+        <div class="fixed-demo__label fixed-demo__label--fixed">Stays fixed (not scaled)</div>
         <div class="fixed-demo__items">
           <div class="fixed-demo__item">
             <div class="fixed-demo__bar" style="width: 40px; height: 1px; background: hsl(215 16% 55%)"></div>
-            <span>1px 区切り線 — 常にシャープ</span>
+            <span>1px dividers — always crisp</span>
           </div>
           <div class="fixed-demo__item">
             <div class="fixed-demo__bar" style="width: 20px; height: 20px; border: 1px solid hsl(215 16% 55%); border-radius: 4px"></div>
-            <span>border-radius — サイズではなくスタイル</span>
+            <span>border-radius — style, not size</span>
           </div>
           <div class="fixed-demo__item">
             <div class="fixed-demo__bar" style="width: 20px; height: 20px; border: 1px solid hsl(215 16% 55%)"></div>
-            <span>border-width — 細いまま維持</span>
+            <span>border-width — stays thin</span>
           </div>
           <div class="fixed-demo__item">
-            <div class="fixed-demo__bar" style="width: 40px; height: 20px; background: hsla(0, 0%, 0%, 0.5); border-radius: 3px"></div>
-            <span>overlay opacity — 知覚に基づく</span>
+            <div class="fixed-demo__bar" style="width: 40px; height: 20px; background: hsl(0 0% 0% / 0.5); border-radius: 3px"></div>
+            <span>overlay opacity — perception</span>
           </div>
         </div>
       </div>
@@ -328,7 +328,7 @@ window.addEventListener("wheel", (e) => {
       gap: 0.5rem;
     }
     .fixed-demo__label {
-      font-size: 0.7rem;
+      font-size: 0.75rem;
       font-weight: 700;
       text-transform: uppercase;
       letter-spacing: 0.05em;
@@ -346,7 +346,7 @@ window.addEventListener("wheel", (e) => {
       display: flex;
       align-items: center;
       gap: 10px;
-      font-size: 0.68rem;
+      font-size: 0.75rem;
       color: hsl(215 25% 35%);
     }
     .fixed-demo__bar {
@@ -436,4 +436,4 @@ window.addEventListener("wheel", (e) => {
 
 - [CSS `calc()` — MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/calc)
 - [CSS Custom Properties — MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties)
-- [Tauri WebView2 Zoom Behavior](https://tauri.app/)
+- [Tauri — Build Desktop Apps with Web Technology](https://tauri.app/)

--- a/src/content/docs/methodology/design-systems/display-scale-strategy.mdx
+++ b/src/content/docs/methodology/design-systems/display-scale-strategy.mdx
@@ -1,0 +1,439 @@
+---
+title: Display Scale Strategy
+sidebar_position: 4
+---
+
+import CssPreview from '@/components/CssPreview';
+
+## The Problem
+
+Desktop apps built with web technology (Tauri, Electron) render inside a WebView — essentially a browser window without the browser chrome. Users expect the same zoom behavior they get in native apps: Ctrl+scroll or Ctrl+/- to scale the entire UI.
+
+The obvious approach is to use the browser's native zoom. But in WebView environments, native zoom breaks things:
+
+- **Cursor offset bugs** — at non-100% zoom, the cursor position reported by the WebView diverges from the actual screen position. Drag handles, resize panels, and click targets become misaligned.
+- **Uncontrolled scaling** — native zoom scales *everything* uniformly, including hairline borders and border-radius values that should stay crisp at any scale.
+- **No persistence API** — there is no standard way to save and restore the zoom level across sessions via the WebView API.
+
+The result: users zoom in, panels become undraggable, buttons become unclickable, and restarting the app resets the zoom. The feature that was supposed to improve usability makes the app feel broken.
+
+### Why Not `transform: scale()`?
+
+The next instinct is to wrap the app root in `transform: scale()`:
+
+```css
+#app-root {
+  transform: scale(var(--zoom));
+  transform-origin: top left;
+}
+```
+
+This avoids cursor offset bugs but creates new problems:
+
+- The element's layout size doesn't change — a scaled-up app overflows its container
+- Fixed/sticky positioning breaks inside transformed ancestors
+- Text becomes blurry at non-integer scale factors
+- You need to calculate and apply inverse dimensions to the container
+
+Both approaches — native zoom and transform scale — try to scale the UI from the *outside*. The display scale strategy scales from the *inside*.
+
+## The Solution
+
+Replace browser zoom with a single CSS custom property — `--display-scale` — and multiply all design tokens by it:
+
+```css
+:root {
+  --display-scale: 1; /* default: 100% */
+}
+```
+
+Every token that should scale with zoom uses `calc()`:
+
+```css
+:root {
+  --spacing-md: calc(8px * var(--display-scale));
+  --spacing-lg: calc(12px * var(--display-scale));
+  --font-size-base: calc(14px * var(--display-scale));
+  --toolbar-height: calc(52px * var(--display-scale));
+}
+```
+
+When `--display-scale` changes from `1` to `1.25`, every value recomputes instantly. An 8px gap becomes 10px. A 14px font becomes 17.5px. The toolbar grows from 52px to 65px. The entire UI scales smoothly, proportionally, in a single CSS reflow — no JavaScript layout recalculation needed.
+
+### Defining the Scale Steps
+
+Discrete steps work better than continuous scaling. A predefined set prevents awkward intermediate sizes and makes the feature predictable:
+
+```typescript
+const VALID_SCALES = [0.75, 0.9, 1.0, 1.1, 1.25, 1.5, 1.75, 2.0];
+```
+
+Zoom in/out cycles through these steps. The user picks a scale in settings or via keyboard shortcuts. The app persists the choice and applies it on startup.
+
+### Applying the Scale
+
+The JavaScript side is minimal — just set one CSS property on the root element:
+
+```typescript
+function applyDisplayScale(scale: number): void {
+  document.documentElement.style.setProperty(
+    "--display-scale",
+    String(scale)
+  );
+}
+```
+
+To prevent native zoom from interfering, intercept the default zoom gestures:
+
+```typescript
+// Prevent native zoom, dispatch custom events instead
+window.addEventListener("wheel", (e) => {
+  if (e.ctrlKey) {
+    e.preventDefault();
+    dispatchScaleChange(e.deltaY > 0 ? "out" : "in");
+  }
+}, { passive: false });
+```
+
+The custom event triggers the scale step logic, persists the new value, and calls `applyDisplayScale()`. The CSS does the rest.
+
+## Token Architecture
+
+The key design decision is **what scales and what doesn't**.
+
+### Values That Scale
+
+Everything the user perceives as "the UI" should scale:
+
+| Category | Examples | Formula |
+| --- | --- | --- |
+| Spacing | padding, margin, gap | `calc(Npx * var(--display-scale))` |
+| Font sizes | body text, headings, labels | `calc(Npx * var(--display-scale))` |
+| Icon sizes | toolbar icons, status icons | `calc(Npx * var(--display-scale))` |
+| Component sizes | buttons, checkboxes, toolbar height | `calc(Npx * var(--display-scale))` |
+
+### Values That Stay Fixed
+
+Some values should remain constant regardless of scale:
+
+| Category | Why Fixed | Example |
+| --- | --- | --- |
+| 1px hairlines | Dividers and separators should stay crisp | `--spacing-1px: 1px` |
+| Border radius | Visual rounding is a style choice, not a size | `--radius-md: 4px` |
+| Border width | Thin borders maintain clarity at any scale | `border: 1px solid` |
+| Overlay opacity | Dimming is perception-based, not size-based | `rgba(0, 0, 0, 0.6)` |
+
+The rule of thumb: if the value defines **how big** something is, it scales. If it defines **how it looks** (rounding, borders, opacity), it stays fixed.
+
+## Demos
+
+### Scaled vs Unscaled Tokens
+
+This demo shows the same UI at three different display scales. Notice how spacing, text, and icons scale proportionally while borders and border-radius stay fixed.
+
+<CssPreview client:load
+  title="Display Scale: 75%, 100%, 125%"
+  height={380}
+  html={`    <div class="scale-demo">
+      <div class="scale-demo__col" style="--ds: 0.75">
+        <div class="scale-demo__badge">75%</div>
+        <div class="scale-demo__card">
+          <div class="scale-demo__toolbar">
+            <div class="scale-demo__icon"></div>
+            <div class="scale-demo__icon"></div>
+            <div class="scale-demo__icon"></div>
+          </div>
+          <div class="scale-demo__body">
+            <div class="scale-demo__title">Document Title</div>
+            <div class="scale-demo__text">Body text scales with the display factor. Borders stay thin.</div>
+          </div>
+          <div class="scale-demo__footer">
+            <button class="scale-demo__btn">Save</button>
+          </div>
+        </div>
+      </div>
+      <div class="scale-demo__col" style="--ds: 1.0">
+        <div class="scale-demo__badge">100%</div>
+        <div class="scale-demo__card">
+          <div class="scale-demo__toolbar">
+            <div class="scale-demo__icon"></div>
+            <div class="scale-demo__icon"></div>
+            <div class="scale-demo__icon"></div>
+          </div>
+          <div class="scale-demo__body">
+            <div class="scale-demo__title">Document Title</div>
+            <div class="scale-demo__text">Body text scales with the display factor. Borders stay thin.</div>
+          </div>
+          <div class="scale-demo__footer">
+            <button class="scale-demo__btn">Save</button>
+          </div>
+        </div>
+      </div>
+      <div class="scale-demo__col" style="--ds: 1.25">
+        <div class="scale-demo__badge">125%</div>
+        <div class="scale-demo__card">
+          <div class="scale-demo__toolbar">
+            <div class="scale-demo__icon"></div>
+            <div class="scale-demo__icon"></div>
+            <div class="scale-demo__icon"></div>
+          </div>
+          <div class="scale-demo__body">
+            <div class="scale-demo__title">Document Title</div>
+            <div class="scale-demo__text">Body text scales with the display factor. Borders stay thin.</div>
+          </div>
+          <div class="scale-demo__footer">
+            <button class="scale-demo__btn">Save</button>
+          </div>
+        </div>
+      </div>
+    </div>`}
+  css={`.scale-demo {
+      display: grid;
+      grid-template-columns: 1fr 1fr 1fr;
+      gap: 12px;
+      padding: 1rem;
+      font-family: system-ui, sans-serif;
+      color: hsl(222 47% 11%);
+      align-items: start;
+    }
+    .scale-demo__col {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      align-items: center;
+    }
+    .scale-demo__badge {
+      font-size: 0.65rem;
+      font-weight: 700;
+      color: hsl(221 83% 53%);
+      background: hsl(210 40% 96%);
+      padding: 2px 8px;
+      border-radius: 10px;
+    }
+    .scale-demo__card {
+      background: hsl(230 15% 18%);
+      border: 1px solid hsl(230 15% 28%);
+      border-radius: 4px;
+      overflow: hidden;
+      width: 100%;
+    }
+    .scale-demo__toolbar {
+      display: flex;
+      gap: calc(6px * var(--ds));
+      padding: calc(6px * var(--ds)) calc(8px * var(--ds));
+      border-bottom: 1px solid hsl(230 15% 28%);
+      background: hsl(230 15% 15%);
+    }
+    .scale-demo__icon {
+      width: calc(16px * var(--ds));
+      height: calc(16px * var(--ds));
+      background: hsl(215 16% 55%);
+      border-radius: 3px;
+    }
+    .scale-demo__body {
+      padding: calc(8px * var(--ds)) calc(10px * var(--ds));
+      display: flex;
+      flex-direction: column;
+      gap: calc(4px * var(--ds));
+    }
+    .scale-demo__title {
+      font-size: calc(13px * var(--ds));
+      font-weight: 600;
+      color: hsl(0 0% 93%);
+    }
+    .scale-demo__text {
+      font-size: calc(11px * var(--ds));
+      color: hsl(215 16% 65%);
+      line-height: 1.4;
+    }
+    .scale-demo__footer {
+      padding: calc(6px * var(--ds)) calc(10px * var(--ds));
+      border-top: 1px solid hsl(230 15% 28%);
+      display: flex;
+      justify-content: flex-end;
+    }
+    .scale-demo__btn {
+      font-size: calc(11px * var(--ds));
+      padding: calc(3px * var(--ds)) calc(10px * var(--ds));
+      background: hsl(221 83% 53%);
+      color: hsl(0 0% 100%);
+      border: none;
+      border-radius: 3px;
+      cursor: pointer;
+      font-weight: 600;
+    }`} />
+
+### Fixed vs Scaled Values
+
+This demo highlights the difference between values that scale and values that stay fixed. The border, border-radius, and divider thickness remain constant — only the content dimensions change.
+
+<CssPreview client:load
+  title="What Scales vs What Stays Fixed"
+  height={300}
+  html={`    <div class="fixed-demo">
+      <div class="fixed-demo__section">
+        <div class="fixed-demo__label">Scales with --display-scale</div>
+        <div class="fixed-demo__items">
+          <div class="fixed-demo__item">
+            <div class="fixed-demo__bar" style="width: 40px; height: 8px; background: hsl(221 83% 53%)"></div>
+            <span>spacing (8px → 10px → 12px)</span>
+          </div>
+          <div class="fixed-demo__item">
+            <span style="font-size: 11px; font-weight: 600">Aa</span>
+            <span>font-size (14px → 17.5px → 21px)</span>
+          </div>
+          <div class="fixed-demo__item">
+            <div class="fixed-demo__bar" style="width: 16px; height: 16px; background: hsl(142 50% 40%); border-radius: 3px"></div>
+            <span>icon size (16px → 20px → 24px)</span>
+          </div>
+          <div class="fixed-demo__item">
+            <div class="fixed-demo__bar" style="width: 60px; height: 12px; background: hsl(262 50% 55%); border-radius: 3px"></div>
+            <span>button/toolbar height</span>
+          </div>
+        </div>
+      </div>
+      <div class="fixed-demo__section">
+        <div class="fixed-demo__label fixed-demo__label--fixed">Stays fixed (not scaled)</div>
+        <div class="fixed-demo__items">
+          <div class="fixed-demo__item">
+            <div class="fixed-demo__bar" style="width: 40px; height: 1px; background: hsl(215 16% 55%)"></div>
+            <span>1px dividers — always crisp</span>
+          </div>
+          <div class="fixed-demo__item">
+            <div class="fixed-demo__bar" style="width: 20px; height: 20px; border: 1px solid hsl(215 16% 55%); border-radius: 4px"></div>
+            <span>border-radius — style, not size</span>
+          </div>
+          <div class="fixed-demo__item">
+            <div class="fixed-demo__bar" style="width: 20px; height: 20px; border: 1px solid hsl(215 16% 55%)"></div>
+            <span>border-width — stays thin</span>
+          </div>
+          <div class="fixed-demo__item">
+            <div class="fixed-demo__bar" style="width: 40px; height: 20px; background: hsla(0, 0%, 0%, 0.5); border-radius: 3px"></div>
+            <span>overlay opacity — perception</span>
+          </div>
+        </div>
+      </div>
+    </div>`}
+  css={`.fixed-demo {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+      padding: 1rem;
+      font-family: system-ui, sans-serif;
+      color: hsl(222 47% 11%);
+    }
+    .fixed-demo__section {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+    .fixed-demo__label {
+      font-size: 0.7rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: hsl(221 83% 53%);
+    }
+    .fixed-demo__label--fixed {
+      color: hsl(215 16% 47%);
+    }
+    .fixed-demo__items {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+    .fixed-demo__item {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      font-size: 0.68rem;
+      color: hsl(215 25% 35%);
+    }
+    .fixed-demo__bar {
+      flex-shrink: 0;
+    }`} />
+
+## Tailwind v4 Integration
+
+In a Tailwind v4 project with the [tight token strategy](./tight-token-strategy/), declare base values in `@theme` and override them with scaled values in `:root`:
+
+```css
+/* tokens.css */
+@theme {
+  /* Base values — used by Tailwind for class generation */
+  --spacing-sm: 6px;
+  --spacing-md: 8px;
+  --spacing-lg: 12px;
+  --spacing-xl: 16px;
+
+  --font-size-sm: 12px;
+  --font-size-base: 14px;
+  --font-size-lg: 16px;
+
+  --spacing-icon-sm: 12px;
+  --spacing-icon-md: 16px;
+  --spacing-icon-lg: 20px;
+}
+
+:root {
+  --display-scale: 1;
+
+  /* Runtime overrides — multiply by display-scale */
+  --spacing-sm: calc(6px * var(--display-scale));
+  --spacing-md: calc(8px * var(--display-scale));
+  --spacing-lg: calc(12px * var(--display-scale));
+  --spacing-xl: calc(16px * var(--display-scale));
+
+  --font-size-sm: calc(12px * var(--display-scale));
+  --font-size-base: calc(14px * var(--display-scale));
+  --font-size-lg: calc(16px * var(--display-scale));
+
+  --spacing-icon-sm: calc(12px * var(--display-scale));
+  --spacing-icon-md: calc(16px * var(--display-scale));
+  --spacing-icon-lg: calc(20px * var(--display-scale));
+}
+```
+
+The `@theme` block gives Tailwind the base values it needs for class generation. The `:root` block overrides them at runtime with the scaled versions. Tailwind classes like `p-lg`, `text-base`, and `w-icon-md` automatically use the scaled values — no changes needed in component code.
+
+### One-Off Scaled Values
+
+For component-specific dimensions not in the token set, use `calc()` directly in arbitrary values:
+
+```html
+<!-- Scaled arbitrary value -->
+<div class="w-[calc(240px*var(--display-scale))]">Sidebar</div>
+
+<!-- Or define a component token -->
+<style>
+  .sidebar { width: calc(240px * var(--display-scale)); }
+</style>
+```
+
+## Common Mistakes
+
+- **Scaling border-radius** — a 4px corner radius looks right at any scale; scaling it to 5px at 125% adds no value and creates inconsistency when comparing elements at different scales
+- **Scaling 1px borders** — hairline borders become blurry at non-integer scales; keeping them at 1px maintains visual clarity
+- **Forgetting to prevent native zoom** — if you don't intercept Ctrl+wheel and Ctrl+/-, users trigger both native zoom *and* your custom scale, causing double-scaling
+- **Using continuous scale** — free-form scale values (e.g., 1.137) create pixel-rounding artifacts; use a predefined step set instead
+- **Mixing scaled and unscaled spacing** — using `gap: 12px` instead of `gap: var(--spacing-lg)` in one component breaks the consistency; once you adopt display scale, *all* spacing must go through the system
+- **Scaling with `transform: scale()`** — this does not change the element's layout size, breaks fixed/sticky positioning, and causes text blur; it is not a substitute for token-based scaling
+
+## When to Use
+
+- **Desktop web apps** — Tauri, Electron, or any WebView-based desktop application where users expect zoom functionality
+- **Apps with drag/resize interactions** — native zoom breaks cursor positioning for drag handles, panel resizers, and canvas interactions
+- **Design systems with tight tokens** — display scale integrates naturally when every value already flows through CSS custom properties
+- **Any app that needs user-configurable UI density** — the same mechanism supports accessibility zoom, compact mode, and large-text mode
+
+### When NOT to Use
+
+- **Websites viewed in regular browsers** — browser zoom works correctly in standard web contexts; adding custom zoom creates a worse experience
+- **Static content sites** — blogs, documentation, marketing pages have no drag interactions and benefit from native zoom + responsive design
+- **Apps that use `rem` throughout** — if all values are `rem`-based, changing the root `font-size` achieves a similar effect more simply
+
+## References
+
+- [CSS `calc()` — MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/calc)
+- [CSS Custom Properties — MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties)
+- [Tauri WebView2 Zoom Behavior](https://tauri.app/)

--- a/src/content/docs/methodology/design-systems/display-scale-strategy.mdx
+++ b/src/content/docs/methodology/design-systems/display-scale-strategy.mdx
@@ -203,7 +203,7 @@ This demo shows the same UI at three different display scales. Notice how spacin
       align-items: center;
     }
     .scale-demo__badge {
-      font-size: 0.65rem;
+      font-size: 0.75rem;
       font-weight: 700;
       color: hsl(221 83% 53%);
       background: hsl(210 40% 96%);
@@ -308,7 +308,7 @@ This demo highlights the difference between values that scale and values that st
             <span>border-width — stays thin</span>
           </div>
           <div class="fixed-demo__item">
-            <div class="fixed-demo__bar" style="width: 40px; height: 20px; background: hsla(0, 0%, 0%, 0.5); border-radius: 3px"></div>
+            <div class="fixed-demo__bar" style="width: 40px; height: 20px; background: hsl(0 0% 0% / 0.5); border-radius: 3px"></div>
             <span>overlay opacity — perception</span>
           </div>
         </div>
@@ -328,7 +328,7 @@ This demo highlights the difference between values that scale and values that st
       gap: 0.5rem;
     }
     .fixed-demo__label {
-      font-size: 0.7rem;
+      font-size: 0.75rem;
       font-weight: 700;
       text-transform: uppercase;
       letter-spacing: 0.05em;
@@ -346,7 +346,7 @@ This demo highlights the difference between values that scale and values that st
       display: flex;
       align-items: center;
       gap: 10px;
-      font-size: 0.68rem;
+      font-size: 0.75rem;
       color: hsl(215 25% 35%);
     }
     .fixed-demo__bar {
@@ -436,4 +436,4 @@ For component-specific dimensions not in the token set, use `calc()` directly in
 
 - [CSS `calc()` — MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/calc)
 - [CSS Custom Properties — MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties)
-- [Tauri WebView2 Zoom Behavior](https://tauri.app/)
+- [Tauri — Build Desktop Apps with Web Technology](https://tauri.app/)


### PR DESCRIPTION
## Summary
- Add new article covering `--display-scale` CSS custom property for desktop app zoom (Tauri/Electron)
- Explains token-based scaling architecture: what scales vs what stays fixed
- Includes Tailwind v4 integration guidance and common mistakes
- Both English and Japanese versions with interactive CssPreview demos

## Changes
- New EN article: `src/content/docs/methodology/design-systems/display-scale-strategy.mdx`
- New JA article: `src/content/docs-ja/methodology/design-systems/display-scale-strategy.mdx`
- Updated `descriptions.json` with new article entry for css-wisdom skill
- Review fixes: synced CssPreview blocks between EN/JA, fixed hsla() syntax, bumped font sizes to 0.75rem minimum, corrected Tauri reference link label

## Test Plan
- [x] `pnpm check` passes
- [x] `pnpm build` succeeds (205 pages)
- [x] CI checks pass (Type Check, Build, Link Check, Preview Deploy)
- [ ] Visual review of CssPreview demos on preview deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)