### PR TITLE
fix: remove pnpm cache from setup-node and purge artifacts

### DIFF
--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -40,7 +40,6 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 22
-          cache: pnpm
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Build site

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -29,7 +29,6 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 22
-          cache: pnpm
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Run type checking
@@ -52,7 +51,6 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 22
-          cache: pnpm
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Build site
@@ -80,7 +78,6 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 22
-          cache: pnpm
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Download build artifact

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -37,7 +37,6 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 22
-          cache: pnpm
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Build


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-css-wisdom/issues/31

---

## Summary
- Remove `cache: pnpm` from all `actions/setup-node` steps in workflow files
- Purge existing GitHub Actions cache (1 entry) and expired artifacts (100 entries)

## Changes
- **main-deploy.yml**: Removed `cache: pnpm` from build job setup-node step
- **pr-checks.yml**: Removed `cache: pnpm` from typecheck, build, and link-check job setup-node steps
- **preview-deploy.yml**: Removed `cache: pnpm` from build-and-deploy job setup-node step
- Purged all GitHub Actions cache entries via `gh cache delete`
- Purged 100 expired artifacts via GitHub API

## Test Plan
- [x] CI passed: Type Check, Build, Link Check, Preview Deploy all green