### PR TITLE
fix: add plugins prop to TailwindPreview for typography support

### DIFF
--- a/src/components/tailwind-preview/tailwind-preview.tsx
+++ b/src/components/tailwind-preview/tailwind-preview.tsx
@@ -8,15 +8,18 @@ interface TailwindPreviewProps {
   title?: string;
   height?: number;
   defaultOpen?: boolean;
+  plugins?: string[];
 }
 
-function buildSrcdoc(html: string, css?: string): string {
+function buildSrcdoc(html: string, css?: string, plugins?: string[]): string {
+  const pluginQuery =
+    plugins && plugins.length > 0 ? `?plugins=${plugins.join(",")}` : "";
   return `<!doctype html>
 <html>
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<script src="https://cdn.tailwindcss.com"></script>
+<script src="https://cdn.tailwindcss.com${pluginQuery}"></script>
 ${css ? `<style>${css}</style>` : ""}
 </head>
 <body>${html}</body>
@@ -29,8 +32,9 @@ export default function TailwindPreview({
   title,
   height,
   defaultOpen,
+  plugins,
 }: TailwindPreviewProps): ReactNode {
-  const srcdoc = useMemo(() => buildSrcdoc(html, css), [html, css]);
+  const srcdoc = useMemo(() => buildSrcdoc(html, css, plugins), [html, css, plugins]);
 
   return (
     <PreviewBase

--- a/src/content/docs-ja/typography/text-control/prose-heading-spacing.mdx
+++ b/src/content/docs-ja/typography/text-control/prose-heading-spacing.mdx
@@ -792,6 +792,7 @@ Tailwind v4 の CSS ファーストな設定では、スタイルシートにセ
 
 <TailwindPreview client:load
   title="Tailwind: @tailwindcss/typography が連続する見出しを処理"
+  plugins={["typography"]}
   html={`
 <div class="grid grid-cols-2 gap-8 p-6">
   <div>

--- a/src/content/docs/typography/text-control/prose-heading-spacing.mdx
+++ b/src/content/docs/typography/text-control/prose-heading-spacing.mdx
@@ -792,6 +792,7 @@ This works but is difficult to read and maintain. Prefer the CSS `@layer` approa
 
 <TailwindPreview client:load
   title="Tailwind: @tailwindcss/typography Handles Consecutive Headings"
+  plugins={["typography"]}
   html={`
 <div class="grid grid-cols-2 gap-8 p-6">
   <div>


### PR DESCRIPTION
## Summary
- The "WITH PROSE CLASS" side of the prose-heading-spacing demo was rendering unstyled because `prose prose-sm max-w-none` requires `@tailwindcss/typography`, which the Tailwind Play CDN does not load without the `?plugins=typography` query parameter
- Adds `plugins?: string[]` prop to `TailwindPreview` that appends `?plugins=<list>` to the CDN URL when provided
- Updates EN and JA `prose-heading-spacing.mdx` to pass `plugins={["typography"]}` on the affected demo

## Changes
- `src/components/tailwind-preview/tailwind-preview.tsx`: added `plugins?: string[]` prop; `buildSrcdoc` now appends `?plugins=<csv>` to the CDN script URL when plugins are specified
- `src/content/docs/typography/text-control/prose-heading-spacing.mdx`: added `plugins={["typography"]}` to the `TailwindPreview` component
- `src/content/docs-ja/typography/text-control/prose-heading-spacing.mdx`: same change for the Japanese counterpart

## Test Plan
- Open the prose-heading-spacing page and verify the "WITH PROSE CLASS" column now shows proper typography styles (tighter consecutive heading spacing, styled paragraphs)
- Verify other `TailwindPreview` demos (no `plugins` prop) are unaffected