### PR TITLE
ci: remove actions/upload-artifact by collapsing jobs

### DIFF
--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -5,6 +5,9 @@
 #   2. Deploys to Cloudflare Pages (production)
 #   3. Sends IFTTT notification with deploy status
 #
+# Build and deploy run in a single job so the build output stays on the
+# runner filesystem -- no artifacts, no cache transfers, no storage usage.
+#
 # Concurrency: only one production deploy runs at a time.
 # We do NOT cancel in-progress runs -- the earlier deploy should finish.
 
@@ -23,12 +26,12 @@ permissions:
   contents: read
 
 jobs:
-  # ─── Build ────────────────────────────────────────────────────────────
+  # ─── Build and Deploy ─────────────────────────────────────────────────
 
-  build:
-    name: Build
+  build-and-deploy:
+    name: Build and Deploy
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -44,30 +47,10 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Build site
         run: pnpm build
-      - name: Upload build artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: dist-out
-          path: dist/
-          retention-days: 1
-
-  # ─── Deploy ───────────────────────────────────────────────────────────
-
-  deploy:
-    name: Deploy to Cloudflare Pages
-    needs: build
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - name: Download build artifact
-        uses: actions/download-artifact@v7
-        with:
-          name: dist-out
-          path: dist-out/
       - name: Prepare deploy directory
         run: |
           mkdir -p deploy/pj/zcss
-          cp -r dist-out/. deploy/pj/zcss/
+          cp -r dist/. deploy/pj/zcss/
           echo '/ /pj/zcss/ 302' > deploy/_redirects
       - name: Deploy to Cloudflare Pages (production)
         run: |
@@ -84,7 +67,7 @@ jobs:
 
   notify:
     name: Deploy Notification
-    needs: [build, deploy]
+    needs: build-and-deploy
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -94,8 +77,7 @@ jobs:
         env:
           IFTTT_PROD_NOTIFY: ${{ secrets.IFTTT_PROD_NOTIFY }}
           RAW_COMMIT_MSG: ${{ github.event.head_commit.message }}
-          BUILD_RESULT: ${{ needs.build.result }}
-          DEPLOY_RESULT: ${{ needs.deploy.result }}
+          DEPLOY_RESULT: ${{ needs.build-and-deploy.result }}
           GITHUB_SHA_VAL: ${{ github.sha }}
           SERVER_URL: ${{ github.server_url }}
           REPO: ${{ github.repository }}
@@ -103,10 +85,8 @@ jobs:
         run: |
           if [ "$DEPLOY_RESULT" = "success" ]; then
             STATUS="zudo-css deploy succeeded!"
-          elif [ "$BUILD_RESULT" = "failure" ]; then
-            STATUS="zudo-css deploy failed (build)"
           elif [ "$DEPLOY_RESULT" = "failure" ]; then
-            STATUS="zudo-css deploy failed (deploy)"
+            STATUS="zudo-css deploy failed"
           else
             STATUS="zudo-css deploy cancelled"
           fi

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -34,12 +34,17 @@ jobs:
       - name: Run type checking
         run: pnpm check
 
-  # ─── Build ────────────────────────────────────────────────────────────
+  # ─── Build + Link Check + Preview Deploy ──────────────────────────────
+  #
+  # Build, link check, and preview deploy run in a single job so the build
+  # output stays on the runner filesystem -- no artifacts, no cache transfers,
+  # no storage usage. Link check runs before preview deploy so broken links
+  # prevent a preview from being published.
 
-  build:
-    name: Build
+  build-preview:
+    name: Build, Link Check, and Preview Deploy
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -55,56 +60,12 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Build site
         run: pnpm build
-      - name: Upload build artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: dist-out
-          path: dist/
-          retention-days: 1
-
-  # ─── Link Check ──────────────────────────────────────────────────────
-
-  link-check:
-    name: Link Check
-    needs: build
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-      - name: Setup Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version: 22
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-      - name: Download build artifact
-        uses: actions/download-artifact@v7
-        with:
-          name: dist-out
-          path: dist/
       - name: Check links
         run: node scripts/check-links.js
-
-  # ─── Preview Deploy ───────────────────────────────────────────────────
-
-  preview:
-    name: Preview Deploy
-    needs: build
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - name: Download build artifact
-        uses: actions/download-artifact@v7
-        with:
-          name: dist-out
-          path: dist-out/
       - name: Prepare deploy directory
         run: |
           mkdir -p deploy/pj/zcss
-          cp -r dist-out/. deploy/pj/zcss/
+          cp -r dist/. deploy/pj/zcss/
           echo '/ /pj/zcss/ 302' > deploy/_redirects
       - name: Deploy preview to Cloudflare Pages
         id: cf-deploy


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-css-wisdom/issues/38

---

## Summary

- Remove all `actions/upload-artifact` / `actions/download-artifact` usage so CI stops contributing to the zudolab org's shared GitHub Actions storage quota.
- Collapse each pipeline into fewer jobs — the build output stays on the runner filesystem instead of being round-tripped through artifact storage. No cache transfers needed either.
- Net diff: 21 insertions, 80 deletions across the two workflow files.

## Changes

### `main-deploy.yml`
- Merge the old `build` and `deploy` jobs into a single `build-and-deploy` job.
- Update `notify` to depend on only `build-and-deploy` and report a single combined status (the previous build-vs-deploy distinction in the IFTTT payload is dropped, since a failure is just a failure).
- Drop the `actions/upload-artifact@v7` and `actions/download-artifact@v7` steps.
- Drop the now-unused inter-job artifact name `dist-out`.

### `pr-checks.yml`
- Merge the old `build`, `link-check`, and `preview` jobs into a single `build-preview` (`Build, Link Check, and Preview Deploy`) job. `typecheck` stays separate because it never needed build output.
- Drop the `actions/upload-artifact@v7` and `actions/download-artifact@v7` steps.
- **Behavior change**: link check now runs _before_ preview deploy, so broken links block a preview from being published. Previously link check and preview ran in parallel, so a link failure did not prevent the preview.

## Test Plan

- [x] Typecheck passes in CI
- [x] Build + link check + preview deploy all green on this PR
- [ ] After merge, `main-deploy` pipeline produces a successful production deploy and IFTTT notification
- [x] No `actions/upload-artifact` or `actions/download-artifact` references remain anywhere under `.github/`

Closes #38
