### PR TITLE
docs: add Markdown to HTML conversion architecture article (EN/JA)

### DIFF
--- a/.claude/skills/css-wisdom/descriptions.json
+++ b/.claude/skills/css-wisdom/descriptions.json
@@ -76,5 +76,6 @@
   "methodology/design-systems/two-tier-size-strategy.mdx": "Two-tier sizing: base + scale for consistent spacing/typography",
   "methodology/design-systems/display-scale-strategy.mdx": "Custom --display-scale CSS property for desktop app zoom (Tauri/Electron), token-based scaling",
   "typography/font-sizing/three-tier-font-size-strategy.mdx": "Three-tier font-size architecture: base, scale, component",
-  "typography/text-effects/text-outline-and-stroke.mdx": "Text outline/stroke (縁取り): -webkit-text-stroke, text-shadow hack, SVG stroke, feMorphology, paint-order"
+  "typography/text-effects/text-outline-and-stroke.mdx": "Text outline/stroke (縁取り): -webkit-text-stroke, text-shadow hack, SVG stroke, feMorphology, paint-order",
+  "methodology/architecture/mdx-component-architecture.mdx": "MDX component overrides vs container-scoped CSS, cascade layer conflicts with Tailwind v4, server-rendered components"
 }

--- a/src/content/docs-ja/methodology/architecture/mdx-component-architecture.mdx
+++ b/src/content/docs-ja/methodology/architecture/mdx-component-architecture.mdx
@@ -1,0 +1,268 @@
+---
+title: Markdown から HTML への変換アーキテクチャ
+description: MDX コンポーネントオーバーライドによるコンテナスコープ CSS とユーティリティファースト CSS のカスケード競合の解決
+sidebar_position: 5
+---
+
+## 問題
+
+ドキュメントサイトやコンテンツ駆動型アプリケーションでは、Markdown/MDX ファイルを HTML ページに変換するのが一般的です。標準的なアプローチは、レンダリングされた HTML をコンテナ要素で囲み、スコープされた CSS でネイティブ HTML 要素をスタイリングする方法です。
+
+```css
+/* Container-scoped element styling */
+.content :where(h2) {
+  font-size: 1.5rem;
+  font-weight: 700;
+  border-top: 3px solid transparent;
+  border-image: linear-gradient(to right, currentColor, transparent) 1;
+  padding-top: 0.75rem;
+}
+
+.content :where(h3) {
+  font-size: 1.2rem;
+  font-weight: 700;
+  border-top: 2px solid gray;
+  padding-top: 0.5rem;
+}
+
+.content :where(p) {
+  line-height: 1.75;
+}
+
+.content :where(a) {
+  color: var(--color-accent);
+  text-decoration: underline;
+}
+```
+
+このパターンはデフォルトのコンテンツページではうまく機能します。`.content` 内のすべての `<h2>`、`<h3>`、`<p>` が統一的にスタイリングされます。
+
+### 破綻するケース
+
+このアプローチは、同じ HTML 要素をコンテンツスタイリングのコンテキスト**外**で使う必要がある場合や、同じコンテナ内で同じ要素に異なるスタイリングが必要な場合に破綻します。
+
+インタラクティブなフォームコンポーネントを埋め込んだドキュメントページを考えてみましょう。
+
+```jsx
+// Inside a doc page that renders within .content
+<PresetGenerator />
+
+// The component uses h3 for section labels
+function SectionHeading({ children }) {
+  return (
+    <h3 className="text-sm font-semibold">
+      {children}
+    </h3>
+  );
+}
+```
+
+コンポーネントの `<h3>` 要素がコンテナの見出しセレクターにマッチしてしまい、border-top のグラデーション、大きいフォントサイズ、余分なパディングが適用されます。これらはドキュメントの見出しではなくフォームのラベルであるにもかかわらずです。コンポーネントのユーティリティクラス（`text-sm`、`font-semibold`）がコンテナスタイルをオーバーライドすべきですが、それができません。
+
+### ユーティリティクラスが負ける理由
+
+Tailwind CSS v4 では、`@import "tailwindcss/utilities"` によりユーティリティクラスが `@layer` 内に配置されます。
+
+```css
+@import "tailwindcss/preflight";
+@import "tailwindcss/utilities";
+
+/* This comes AFTER the utility import — it's unlayered */
+.content :where(h3) {
+  font-size: 1.2rem;
+  font-weight: 700;
+  border-top: 2px solid gray;
+}
+```
+
+カスケードレイヤー（cascade layers）は厳格な優先順位に従います。**レイヤーに属さないスタイルは、詳細度やソース順序に関係なく、常にレイヤー内のスタイルに勝ちます**。`.content :where(h3)` ルールはレイヤーに属しておらず、Tailwind の `.text-sm` は `@layer utilities` 内にあります。`:where()` の詳細度がゼロであっても、レイヤーに属さないルールが勝ちます。
+
+これにより解決不可能な状況が生まれます。
+
+- ユーティリティクラスでコンテナスタイルをオーバーライドできない
+- より詳細度の高い CSS オーバーライド（`.preset-gen :where(h3) { ... }`）を追加すると、いたちごっこになる
+- `<h3>` を再利用する新しいコンテキストごとに独自のオーバーライドルールが必要になる
+- コンテキスト固有のパッチがコードベースに蓄積し、コンテキストが変わると壊れる
+
+根本的な問題は詳細度ではなく、**2つのスタイリングシステム**（コンテナスコープの CSS とユーティリティファーストの CSS）が異なるカスケードレイヤーに存在し、互いに折り合いをつけられないことです。
+
+## 解決方法
+
+コンテナスコープの要素スタイリングを、MDX レンダリングレイヤーでの**コンポーネントオーバーライド**に置き換えます。コンテナ内のすべての `<h2>` 要素をスタイリングする CSS ルールの代わりに、スタイルを内包した `<h2>` をレンダリングするコンポーネントを作成します。
+
+モダンフレームワーク（Astro、Next.js、Remix）は MDX コンポーネントオーバーライドをサポートしています。これは MDX が生成するデフォルトの HTML 要素をカスタムコンポーネントに置き換える仕組みです。
+
+```tsx
+// content-h2.tsx — replaces <h2> in MDX content
+export function ContentH2({ id, children, ...props }) {
+  return (
+    <h2
+      id={id}
+      className="text-xl font-bold leading-tight pt-3"
+      style={{
+        '--flow-space': 'var(--spacing-2xl)',
+        borderTop: '3px solid transparent',
+        borderImage: 'linear-gradient(to right, currentColor, transparent) 1',
+      }}
+      {...props}
+    >
+      {children}
+    </h2>
+  );
+}
+```
+
+```tsx
+// content-h3.tsx — replaces <h3> in MDX content
+export function ContentH3({ id, children, ...props }) {
+  return (
+    <h3
+      id={id}
+      className="text-lg font-bold leading-snug pt-2"
+      style={{
+        '--flow-space': 'var(--spacing-xl)',
+        borderTop: '2px solid transparent',
+        borderImage: 'linear-gradient(to right, gray, transparent) 1',
+      }}
+      {...props}
+    >
+      {children}
+    </h3>
+  );
+}
+```
+
+レンダリングレイヤーでオーバーライドを登録します。
+
+```tsx
+// component-map.ts
+import { ContentH2 } from './content-h2';
+import { ContentH3 } from './content-h3';
+import { ContentP } from './content-p';
+import { ContentA } from './content-a';
+
+export const htmlOverrides = {
+  h2: ContentH2,
+  h3: ContentH3,
+  p: ContentP,
+  a: ContentA,
+};
+```
+
+### フレームワークとの統合
+
+**Astro** — MDX の `<Content>` コンポーネントに `components` プロパティを渡します。
+
+```astro
+---
+import { htmlOverrides } from './component-map';
+const { Content } = await entry.render();
+---
+
+<article class="content">
+  <Content components={{ ...htmlOverrides, Note, Tip, Warning }} />
+</article>
+```
+
+**Next.js** — `useMDXComponents` または `next-mdx-remote` の `components` プロパティを使います。
+
+```tsx
+import { MDXRemote } from 'next-mdx-remote/rsc';
+import { htmlOverrides } from './component-map';
+
+export default function DocPage({ source }) {
+  return <MDXRemote source={source} components={htmlOverrides} />;
+}
+```
+
+### なぜこれで問題が解決するのか
+
+コンポーネントオーバーライドを使うと次のようになります。
+
+1. **MDX コンテンツの見出し**は `ContentH3` を通してレンダリングされ、border-top のグラデーション、大きいフォントなどが適用されます
+2. **フォームのセクション見出し**は素の `<h3 className="text-sm font-semibold">` を使い、コンテナスタイルは干渉しません
+3. **カスケードの競合がない** — 各コンテキストがレンダリングするコンポーネントを通じて自身のスタイリングを制御します
+4. **単一の情報源** — 見出しのデザインはコンポーネントに存在し、他のルールと競合する CSS ルールには存在しません
+
+コンテナ要素（`.content`）には要素レベルのスタイリングが不要になります。コンテナとしての関心事のみを扱います。
+
+```css
+/* Container-level only — no element styling */
+.content {
+  color: var(--color-fg);
+  font-size: var(--text-body);
+  line-height: 1.75;
+}
+
+/* Flow spacing (vertical rhythm) */
+.content > * + * {
+  margin-top: var(--flow-space, 1rem);
+}
+
+/* Structural rules that depend on sibling adjacency */
+.content :where(h2, h3, h4) + :where(:not(h2, h3, h4)) {
+  --flow-space: 0.5rem;
+}
+```
+
+## グローバル CSS に残すもの
+
+すべてをコンポーネントに移すわけではありません。**要素間の関係**（隣接する兄弟要素、親子構造）に依存するルールはグローバル CSS に残します。コンポーネントは自身の隣接要素について知ることができないためです。
+
+| 関心事 | 配置場所 | 理由 |
+|---|---|---|
+| 見出しのフォント/ボーダー/ウェイト | コンポーネント | 自己完結した外観 |
+| `--flow-space` の値 | コンポーネント（`style` 経由） | 要素レベルのスペーシング宣言 |
+| `> * + *` フロースペーシング | コンテナ CSS | 子要素の `--flow-space` を読み取る |
+| 見出し + 見出しの詰め | コンテナ CSS | 兄弟要素の隣接関係に依存 |
+| 見出し + コンテンツの詰め | コンテナ CSS | 兄弟要素の隣接関係に依存 |
+| プラグインが挿入する要素（自動リンクアンカー） | コンテナ CSS | ビルドプラグインからの横断的関心事 |
+
+## サーバーレンダリングコンポーネント = JavaScript ゼロ
+
+よくある懸念として「すべての見出しに React/Preact コンポーネントを使うと JavaScript のオーバーヘッドが増えるのでは？」というものがあります。
+
+いいえ。モダンな SSR フレームワークでは、クライアントサイドのインタラクティブ指示がないコンポーネントはビルド時にレンダリングされ、静的な HTML を生成します。純粋にテンプレートとして機能します。
+
+**Astro**: `client:load` や `client:visible` のない Preact/React コンポーネントはサーバーレンダリングのみで、JavaScript は一切配信されません。
+
+**Next.js**: Server Components（App Router のデフォルト）はサーバー上でレンダリングされ、クライアントバンドルに影響しません。
+
+コンポーネントはビルド時にのみ存在します。ブラウザが受け取るのは、クラスとインラインスタイルが付いた素の `<h2>`、`<h3>`、`<p>` 要素であり、CSS のみのアプローチが生成するものと区別がつきません。
+
+## 使い分け
+
+| シナリオ | 推奨アプローチ |
+|---|---|
+| コンテンツページのみで再利用の競合がない | コンテナスコープ CSS（よりシンプル） |
+| 同じ要素をコンテンツとインタラクティブコンポーネントの両方で使用 | コンポーネントオーバーライド（競合を排除） |
+| Tailwind v4 で `@layer` とレイヤーに属さないコンテンツスタイルを使用 | コンポーネントオーバーライド（カスケードロックの回避に必須） |
+| 異なるスタイリングが必要な複数のコンテンツコンテキスト | コンポーネントオーバーライド（各コンテキストが独自のコンポーネントを持つ） |
+| 再利用の競合がないマイナーな要素（li、code、hr） | コンテナ CSS（コンポーネントのオーバーヘッドを回避） |
+
+### 実践的な判断基準
+
+コンテナスコープ CSS から始めましょう。よりシンプルで、大半のケースで機能します。
+
+コンテンツページで使われている要素が非コンテンツのコンテキスト（フォーム、インタラクティブパネル、埋め込みツール）でも必要になり、コンテナスタイルが競合を引き起こすことが判明した時点で、コンポーネントオーバーライドに切り替えましょう。これは事前に行う判断ではなく、事後的な判断です。
+
+切り替える場合は、主要な要素（h2、h3、h4、p、a、blockquote、ul、ol、table）をすべてコンポーネントに変換しましょう。一部を CSS のまま残し、一部をコンポーネントにすると、メンテナンスが難しい混在状態になります。マイナーな要素（h5、h6、li、インラインコード、hr、img）は CSS のまま残して構いません。コンテンツコンテキスト外で使われることがほとんどないためです。
+
+## AI がよくやるミス
+
+- アーキテクチャの根本原因に対処せず、より詳細度の高い CSS オーバーライドでカスケードの競合を修正しようとする
+- コンテナスコープスタイルに対してユーティリティクラスの値を強制するために `!important` を使う
+- Tailwind v4 の `@import "tailwindcss/utilities"` がレイヤーに属さない CSS に負ける `@layer` を作成することに気づかない
+- 新しいコンテキストごとにラッパー固有の CSS オーバーライド（`.form :where(h3) { ... }`）を作成する — スケールしないアプローチ
+- 各コンテキストが自身のスタイリングを制御できるようにする代わりに、`border-top: none; border-image: none; font-size: ...` のようなリセットルールを追加して見出しのデザインを完全に剥がしてしまう
+- コンテンツ要素用の React/Preact コンポーネントが JavaScript のオーバーヘッドを追加すると思い込む（実際にはサーバーレンダリングのみ）
+- 明確な境界ルールなしに、一部の要素をコンポーネントに、他をコンテナ CSS にする混在状態にする
+
+## 参考資料
+
+- [Astro MDX Integration - Custom Components](https://docs.astro.build/en/guides/markdown-content/#assigning-custom-components-to-html-elements)
+- [MDX - Using Components](https://mdxjs.com/docs/using-mdx/#components)
+- [Next.js MDX - Custom Elements](https://nextjs.org/docs/app/building-your-application/configuring/mdx#custom-elements)
+- [Component First Strategy](./component-first-strategy.mdx)
+- [Cascade Layers](./cascade-layers.mdx)
+- [:is() and :where() Selectors](../../interactive/selectors/is-where-selectors.mdx)

--- a/src/content/docs/methodology/architecture/mdx-component-architecture.mdx
+++ b/src/content/docs/methodology/architecture/mdx-component-architecture.mdx
@@ -1,5 +1,6 @@
 ---
 title: Markdown to HTML Conversion Architecture
+description: Resolving cascade conflicts between container-scoped CSS and utility-first CSS with MDX component overrides
 sidebar_position: 5
 ---
 
@@ -56,7 +57,7 @@ function SectionHeading({ children }) {
 }
 ```
 
-The component's `<h3>` elements inherit the container's heading styles — border-top gradients, larger font size, extra padding — even though they are form labels, not document headings. The component's utility classes (`text-sm`, `font-semibold`) should override the container styles, but they can't.
+The component's `<h3>` elements match the container's heading selectors — picking up border-top gradients, larger font size, extra padding — even though they are form labels, not document headings. The component's utility classes (`text-sm`, `font-semibold`) should override the container styles, but they can't.
 
 ### Why Utility Classes Lose
 
@@ -229,7 +230,7 @@ No. In modern SSR frameworks, components without client-side interactivity direc
 
 The components exist only at build time. The browser receives plain `<h2>`, `<h3>`, `<p>` elements with classes and inline styles — indistinguishable from what a CSS-only approach would produce.
 
-## When to Use Each Approach
+## When to Use
 
 | Scenario | Recommended approach |
 |---|---|

--- a/src/content/docs/methodology/architecture/mdx-component-architecture.mdx
+++ b/src/content/docs/methodology/architecture/mdx-component-architecture.mdx
@@ -1,0 +1,267 @@
+---
+title: Markdown to HTML Conversion Architecture
+sidebar_position: 5
+---
+
+## The Problem
+
+Documentation sites and content-driven applications commonly convert Markdown/MDX files into HTML pages. The standard approach is to wrap the rendered HTML in a container element and style native HTML elements with scoped CSS:
+
+```css
+/* Container-scoped element styling */
+.content :where(h2) {
+  font-size: 1.5rem;
+  font-weight: 700;
+  border-top: 3px solid transparent;
+  border-image: linear-gradient(to right, currentColor, transparent) 1;
+  padding-top: 0.75rem;
+}
+
+.content :where(h3) {
+  font-size: 1.2rem;
+  font-weight: 700;
+  border-top: 2px solid gray;
+  padding-top: 0.5rem;
+}
+
+.content :where(p) {
+  line-height: 1.75;
+}
+
+.content :where(a) {
+  color: var(--color-accent);
+  text-decoration: underline;
+}
+```
+
+This pattern works well for the default content pages — every `<h2>`, `<h3>`, `<p>` inside `.content` gets styled uniformly.
+
+### The Breakdown
+
+The approach falls apart when you need to use the same HTML elements **outside the content styling context** — or when you need different styling for the same elements within the container.
+
+Consider a documentation page that embeds an interactive form component:
+
+```jsx
+// Inside a doc page that renders within .content
+<PresetGenerator />
+
+// The component uses h3 for section labels
+function SectionHeading({ children }) {
+  return (
+    <h3 className="text-sm font-semibold">
+      {children}
+    </h3>
+  );
+}
+```
+
+The component's `<h3>` elements inherit the container's heading styles — border-top gradients, larger font size, extra padding — even though they are form labels, not document headings. The component's utility classes (`text-sm`, `font-semibold`) should override the container styles, but they can't.
+
+### Why Utility Classes Lose
+
+In Tailwind CSS v4, `@import "tailwindcss/utilities"` places utility classes inside a `@layer`:
+
+```css
+@import "tailwindcss/preflight";
+@import "tailwindcss/utilities";
+
+/* This comes AFTER the utility import — it's unlayered */
+.content :where(h3) {
+  font-size: 1.2rem;
+  font-weight: 700;
+  border-top: 2px solid gray;
+}
+```
+
+Cascade layers follow strict priority: **unlayered styles always beat layered styles**, regardless of specificity or source order. The `.content :where(h3)` rule is unlayered, while Tailwind's `.text-sm` is inside `@layer utilities`. Even though `:where()` has zero specificity, the unlayered rule wins.
+
+This creates an impossible situation:
+
+- You can't override container styles with utility classes
+- Adding more specific CSS overrides (`.preset-gen :where(h3) { ... }`) leads to an arms race
+- Each new context that reuses `<h3>` needs its own override rules
+- The codebase accumulates context-specific patches that break when contexts change
+
+The root issue isn't specificity — it's that **two styling systems** (container-scoped CSS and utility-first CSS) occupy different cascade layers and cannot negotiate with each other.
+
+## The Solution
+
+Replace container-scoped element styling with **component overrides** at the MDX rendering layer. Instead of a CSS rule that styles all `<h2>` elements inside a container, create a component that renders `<h2>` with the styles built in.
+
+Modern frameworks (Astro, Next.js, Remix) support MDX component overrides — a mechanism where you replace the default HTML elements that MDX generates with custom components:
+
+```tsx
+// content-h2.tsx — replaces <h2> in MDX content
+export function ContentH2({ id, children, ...props }) {
+  return (
+    <h2
+      id={id}
+      className="text-xl font-bold leading-tight pt-3"
+      style={{
+        '--flow-space': 'var(--spacing-2xl)',
+        borderTop: '3px solid transparent',
+        borderImage: 'linear-gradient(to right, currentColor, transparent) 1',
+      }}
+      {...props}
+    >
+      {children}
+    </h2>
+  );
+}
+```
+
+```tsx
+// content-h3.tsx — replaces <h3> in MDX content
+export function ContentH3({ id, children, ...props }) {
+  return (
+    <h3
+      id={id}
+      className="text-lg font-bold leading-snug pt-2"
+      style={{
+        '--flow-space': 'var(--spacing-xl)',
+        borderTop: '2px solid transparent',
+        borderImage: 'linear-gradient(to right, gray, transparent) 1',
+      }}
+      {...props}
+    >
+      {children}
+    </h3>
+  );
+}
+```
+
+Register the overrides at the rendering layer:
+
+```tsx
+// component-map.ts
+import { ContentH2 } from './content-h2';
+import { ContentH3 } from './content-h3';
+import { ContentP } from './content-p';
+import { ContentA } from './content-a';
+
+export const htmlOverrides = {
+  h2: ContentH2,
+  h3: ContentH3,
+  p: ContentP,
+  a: ContentA,
+};
+```
+
+### Framework Integration
+
+**Astro** — pass `components` prop to the MDX `<Content>` component:
+
+```astro
+---
+import { htmlOverrides } from './component-map';
+const { Content } = await entry.render();
+---
+
+<article class="content">
+  <Content components={{ ...htmlOverrides, Note, Tip, Warning }} />
+</article>
+```
+
+**Next.js** — use `useMDXComponents` or the `components` prop in `next-mdx-remote`:
+
+```tsx
+import { MDXRemote } from 'next-mdx-remote/rsc';
+import { htmlOverrides } from './component-map';
+
+export default function DocPage({ source }) {
+  return <MDXRemote source={source} components={htmlOverrides} />;
+}
+```
+
+### Why This Solves the Problem
+
+With component overrides:
+
+1. **MDX content headings** render through `ContentH3` — with border-top gradient, larger font, etc.
+2. **Form section headings** use plain `<h3 className="text-sm font-semibold">` — no container styles interfere
+3. **No cascade conflict** — each context controls its own styling via the component it chooses to render
+4. **Single source of truth** — heading design lives in the component, not in a CSS rule that fights with other rules
+
+The container element (`.content`) no longer needs element-level styling. It handles only container concerns:
+
+```css
+/* Container-level only — no element styling */
+.content {
+  color: var(--color-fg);
+  font-size: var(--text-body);
+  line-height: 1.75;
+}
+
+/* Flow spacing (vertical rhythm) */
+.content > * + * {
+  margin-top: var(--flow-space, 1rem);
+}
+
+/* Structural rules that depend on sibling adjacency */
+.content :where(h2, h3, h4) + :where(:not(h2, h3, h4)) {
+  --flow-space: 0.5rem;
+}
+```
+
+## What Stays in Global CSS
+
+Not everything moves into components. Rules that depend on **relationships between elements** — sibling adjacency, parent-child structure — belong in global CSS because a component cannot reason about its neighbors:
+
+| Concern | Where it lives | Why |
+|---|---|---|
+| Heading font/border/weight | Component | Self-contained appearance |
+| `--flow-space` value | Component (via `style`) | Element-level spacing declaration |
+| `> * + *` flow spacing | Container CSS | Reads `--flow-space` from children |
+| Heading + heading tightening | Container CSS | Depends on sibling adjacency |
+| Heading + content tightening | Container CSS | Depends on sibling adjacency |
+| Plugin-injected elements (auto-link anchors) | Container CSS | Cross-cutting concern from build plugins |
+
+## Server-Rendered Components = Zero JavaScript
+
+A common concern: "Won't React/Preact components for every heading add JavaScript overhead?"
+
+No. In modern SSR frameworks, components without client-side interactivity directives are rendered at build time and produce static HTML. They are purely templates:
+
+**Astro**: Any Preact/React component without `client:load` or `client:visible` is server-rendered only — zero JavaScript shipped.
+
+**Next.js**: Server Components (the default in App Router) render on the server — no client bundle impact.
+
+The components exist only at build time. The browser receives plain `<h2>`, `<h3>`, `<p>` elements with classes and inline styles — indistinguishable from what a CSS-only approach would produce.
+
+## When to Use Each Approach
+
+| Scenario | Recommended approach |
+|---|---|
+| Content pages only, no reuse conflicts | Container-scoped CSS (simpler) |
+| Same elements used in content AND interactive components | Component overrides (eliminates conflicts) |
+| Tailwind v4 with `@layer` and unlayered content styles | Component overrides (required to avoid cascade lock) |
+| Multiple content contexts with different styling needs | Component overrides (each context gets its own components) |
+| Minor elements (li, code, hr) with no reuse conflicts | Container CSS (avoid component overhead) |
+
+### Practical Decision Rule
+
+Start with container-scoped CSS. It is simpler and works for the majority of cases.
+
+Switch to component overrides when you discover that an element used in content pages is also needed in a non-content context (forms, interactive panels, embedded tools) and the container styles create conflicts. This is a reactive decision, not a preemptive one.
+
+Once you switch, convert all primary elements (h2, h3, h4, p, a, blockquote, ul, ol, table) to components. Leaving some as CSS and some as components creates a confusing hybrid that is harder to maintain. Minor elements (h5, h6, li, inline code, hr, img) can stay as CSS because they rarely appear outside content contexts.
+
+## Common AI Mistakes
+
+- Attempting to fix cascade conflicts with more specific CSS overrides instead of addressing the architectural root cause
+- Using `!important` to force utility class values over container-scoped styles
+- Not realizing that Tailwind v4's `@import "tailwindcss/utilities"` creates a `@layer` that loses to unlayered CSS
+- Creating wrapper-specific CSS overrides (`.form :where(h3) { ... }`) for every new context — an approach that doesn't scale
+- Adding `border-top: none; border-image: none; font-size: ...` reset rules that strip heading design entirely instead of letting each context control its own styling
+- Assuming that React/Preact components for content elements add JavaScript overhead (they don't — server-rendered only)
+- Mixing some elements as components and others as container CSS without a clear boundary rule
+
+## References
+
+- [Astro MDX Integration - Custom Components](https://docs.astro.build/en/guides/markdown-content/#assigning-custom-components-to-html-elements)
+- [MDX - Using Components](https://mdxjs.com/docs/using-mdx/#components)
+- [Next.js MDX - Custom Elements](https://nextjs.org/docs/app/building-your-application/configuring/mdx#custom-elements)
+- [Component First Strategy](./component-first-strategy.mdx)
+- [Cascade Layers](./cascade-layers.mdx)
+- [:is() and :where() Selectors](../../interactive/selectors/is-where-selectors.mdx)


### PR DESCRIPTION
## Summary
- Add new article documenting the problem of container-scoped element styling conflicting with utility-first CSS (Tailwind v4 cascade layers)
- Covers the root cause, the solution (MDX component overrides for Astro/Next.js), and practical decision rules
- Includes both English and Japanese translations
- Adds css-wisdom skill description for the new article

## Changes
- New EN article: `src/content/docs/methodology/architecture/mdx-component-architecture.mdx`
- New JA article: `src/content/docs-ja/methodology/architecture/mdx-component-architecture.mdx`
- Updated: `.claude/skills/css-wisdom/descriptions.json` (new entry for skill indexing)
- Review fixes: added `description` frontmatter, fixed "inherit" wording accuracy, renamed heading to "When to Use" per convention

## Test Plan
- [x] Build passes (`pnpm build` — 207 pages)
- [x] EN article renders at `/docs/methodology/architecture/mdx-component-architecture/`
- [x] JA article renders at `/ja/docs/methodology/architecture/mdx-component-architecture/`
- [x] Sidebar navigation shows article at position 5 in Architecture category (both locales)
- [x] Locale switcher links work between EN/JA versions
- [x] Internal links to sibling articles resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)