### PR TITLE
docs(typography): long URL and path wrapping article (EN + JA)

### DIFF
--- a/src/content/docs-ja/typography/text-control/long-url-and-path-wrapping.mdx
+++ b/src/content/docs-ja/typography/text-control/long-url-and-path-wrapping.mdx
@@ -29,7 +29,7 @@ C:\Users\Example\AppData\Local\Temp\build-artifact-2026-04-24.log
 | `word-break: break-all` | 任意の2文字間、どこででも折り返す | 本文を単語の途中で粉々にし、区切り文字を無視し、ページの残りの部分を読めなくする |
 | `overflow-wrap: anywhere` | 同じ効果だが、単語があふれる場合にのみ発動する | 依然として区切り文字を無視する。長い単語は `/` や `?` ではなく任意の文字位置で折り返される |
 | `hyphens: auto` | 辞書由来の位置にソフトハイフンを挿入する | URLやパスには何もしない — 辞書の単語ではないため |
-| `word-break: break-word` | `overflow-wrap: break-word` のレガシーエイリアス | 非標準の表記。動作は `overflow-wrap: break-word` と同じなので、標準の形式を使うべき |
+| `word-break: break-word` | Chromeレガシーの非標準値。より積極的に折り返し、おおむね `word-break: normal` と `overflow-wrap: anywhere` の組み合わせに相当する | `overflow-wrap: break-word` の同義ではない。緊急時の折り返しの積極度は `anywhere` と同等で、同じく区切り文字を無視する。使わず、上記の標準プロパティを選ぶこと |
 
 `https://example.com/docs/a/b/c` のようなURLに対する正しい答えは、ほぼ常に「`/` の後で折り返す」です。`C:\Users\Example` のようなパスに対する正しい答えは「`\` の後で折り返す」です。上記のプロパティのどれもこのことを知りません。
 

--- a/src/content/docs-ja/typography/text-control/long-url-and-path-wrapping.mdx
+++ b/src/content/docs-ja/typography/text-control/long-url-and-path-wrapping.mdx
@@ -1,0 +1,531 @@
+---
+title: 長い URL とパスの折り返し
+description: 長い URL・ファイルパス・パッケージ識別子を、本文（prose）やコードを壊さずに区切り文字を意識した位置で折り返す方法。
+sidebar_position: 5
+---
+
+import CssPreview from '@/components/CssPreview';
+
+## 問題
+
+サイドバー、テーブル、チャットバブル、コールアウトボックスなどの幅の狭いコンテナには、ブラウザにとって折り返し位置が判断できないような長い一塊のトークンが日常的に流し込まれます。
+
+```text
+@scope/org-name/packages/feature-module/src/components/widget.tsx
+https://example.com/docs/guide/section?utm_source=newsletter&utm_medium=email&utm_campaign=launch
+C:\Users\Example\AppData\Local\Temp\build-artifact-2026-04-24.log
+```
+
+ブラウザはデフォルトでこれらをすべて1つの単語として扱います。トークンはコンテナの端を突き破り、レイアウト全体に横スクロールバーを発生させたり、隣接する列にはみ出したりします。AIエージェントは `word-break: break-all` や `overflow-wrap: anywhere` に飛びついて修正を投入し、1週間後にバグ報告を受け取ります。段落という段落が単語の途中でランダムに折り返されるようになり、本文が読めなくなった、というものです。
+
+本当の問題は、ブラウザがどのトークンがURLに似ていて、どのトークンが本文なのかを知らないということです。一律のルールは幅の狭いコンテナの問題を解決する代わりに、ページ上の他のすべてを犠牲にします。
+
+## ワンライナーでは不十分な理由
+
+これらのプロパティにはそれぞれ用途がありますが、汎用的な解決策になるものはありません。
+
+| プロパティ | 効果 | なぜ正解にならないか |
+|---|---|---|
+| `word-break: break-all` | 任意の2文字間、どこででも折り返す | 本文を単語の途中で粉々にし、区切り文字を無視し、ページの残りの部分を読めなくする |
+| `overflow-wrap: anywhere` | 同じ効果だが、単語があふれる場合にのみ発動する | 依然として区切り文字を無視する。長い単語は `/` や `?` ではなく任意の文字位置で折り返される |
+| `hyphens: auto` | 辞書由来の位置にソフトハイフンを挿入する | URLやパスには何もしない — 辞書の単語ではないため |
+| `word-break: break-word` | `overflow-wrap: break-word` のレガシーエイリアス | 非標準の表記。動作は `overflow-wrap: break-word` と同じなので、標準の形式を使うべき |
+
+`https://example.com/docs/a/b/c` のようなURLに対する正しい答えは、ほぼ常に「`/` の後で折り返す」です。`C:\Users\Example` のようなパスに対する正しい答えは「`\` の後で折り返す」です。上記のプロパティのどれもこのことを知りません。
+
+## `<wbr>` 注入戦略
+
+`<wbr>` は **word break opportunity** 要素です。ブラウザに「ここで折り返す必要があるなら、ここは折り返していい場所だ」と伝えます。折り返しが必要ない場合、視覚的な出力はゼロです。
+
+`<wbr>` の検証済みの性質:
+
+- グリフはレンダリングされない — 視覚的なスペースを取らない
+- スクリーンリーダーには読み上げられない — アクセシビリティのノイズにならない
+- クリップボードにコピーされない — ユーザーがURLを選択すると元の文字列がそのまま得られる
+- 選択中のキャレットは正常に動作する — 1文字ずれるようなことはない
+- SSR-safe — 単なるHTMLで、クライアントサイドのJavaScriptは不要
+
+戦略はこうです。URLに似たトークンの中の区切り文字を見つけて、各区切り文字の **後** に `<wbr>` を注入します。レンダリングされた文字列はコピー時にバイト一致します。トークンは任意の文字位置ではなく、意味のある境界で折り返されます。
+
+前:
+
+```html
+<code>@scope/org-name/packages/feature-module/src/widget.tsx</code>
+```
+
+後:
+
+```html
+<code>@scope/<wbr>org-name/<wbr>packages/<wbr>feature-module/<wbr>src/<wbr>widget.tsx</code>
+```
+
+<CssPreview client:load
+  title="D1 — 240px カラムでの4つの折り返し戦略"
+  height={520}
+  defaultOpen={false}
+  html={`
+    <div class="wrap-demo">
+      <div class="wrap-demo__col">
+        <span class="wrap-demo__label">plain (no wrap rule)</span>
+        <div class="wrap-demo__cell wrap-demo__cell--plain">
+          https://example.com/docs/guide/section?utm_source=newsletter&utm_medium=email
+        </div>
+      </div>
+      <div class="wrap-demo__col">
+        <span class="wrap-demo__label">word-break: break-all</span>
+        <div class="wrap-demo__cell wrap-demo__cell--all">
+          https://example.com/docs/guide/section?utm_source=newsletter&utm_medium=email
+        </div>
+      </div>
+      <div class="wrap-demo__col">
+        <span class="wrap-demo__label">overflow-wrap: anywhere</span>
+        <div class="wrap-demo__cell wrap-demo__cell--anywhere">
+          https://example.com/docs/guide/section?utm_source=newsletter&utm_medium=email
+        </div>
+      </div>
+      <div class="wrap-demo__col">
+        <span class="wrap-demo__label">smart-break (wbr + overflow-wrap: break-word)</span>
+        <div class="wrap-demo__cell wrap-demo__cell--smart">
+          https://<wbr>example.com/<wbr>docs/<wbr>guide/<wbr>section?<wbr>utm_source=<wbr>newsletter&<wbr>utm_medium=<wbr>email
+        </div>
+      </div>
+    </div>
+  `}
+  css={`
+    .wrap-demo {
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+      padding: 1rem;
+      background: hsl(30 20% 97%);
+      font-family: system-ui, sans-serif;
+    }
+    .wrap-demo__col {
+      width: 240px;
+      max-width: 100%;
+    }
+    .wrap-demo__label {
+      display: block;
+      font-size: 0.75rem;
+      font-weight: 600;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      color: hsl(30 40% 30%);
+      margin-bottom: 0.35rem;
+    }
+    .wrap-demo__cell {
+      width: 240px;
+      padding: 0.6rem 0.75rem;
+      border: 1px solid hsl(30 20% 80%);
+      border-radius: 6px;
+      background: hsl(0 0% 100%);
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 0.8rem;
+      line-height: 1.5;
+      color: hsl(30 20% 20%);
+    }
+    .wrap-demo__cell--plain {
+      white-space: nowrap;
+      overflow-x: auto;
+    }
+    .wrap-demo__cell--all {
+      word-break: break-all;
+    }
+    .wrap-demo__cell--anywhere {
+      overflow-wrap: anywhere;
+    }
+    .wrap-demo__cell--smart {
+      overflow-wrap: break-word;
+    }
+  `}
+/>
+
+`plain` セルは水平方向にあふれます。`break-all` は任意の文字位置で折り返すため、URLは読めません。`anywhere` も似たように任意の位置で折り返しますが、オーバーフローが起こる場合のみ発動します。`smart-break` は `/`、`?`、`&` の後できれいに折り返します。
+
+<CssPreview client:load
+  title="D2 — 狭いサイドバーでの wbr 注入あり/なしの同じパス"
+  height={340}
+  defaultOpen={false}
+  html={`
+    <div class="sidebar-demo">
+      <div class="sidebar-demo__col">
+        <span class="sidebar-demo__label">No injection</span>
+        <div class="sidebar-demo__panel">
+          <div class="sidebar-demo__title">File:</div>
+          <code class="sidebar-demo__code">@scope/org-name/packages/feature-module/src/components/widget.tsx</code>
+        </div>
+      </div>
+      <div class="sidebar-demo__col">
+        <span class="sidebar-demo__label">wbr injected after each /</span>
+        <div class="sidebar-demo__panel">
+          <div class="sidebar-demo__title">File:</div>
+          <code class="sidebar-demo__code">@scope/<wbr>org-name/<wbr>packages/<wbr>feature-module/<wbr>src/<wbr>components/<wbr>widget.tsx</code>
+        </div>
+      </div>
+    </div>
+  `}
+  css={`
+    .sidebar-demo {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1rem;
+      padding: 1rem;
+      background: hsl(210 20% 97%);
+      font-family: system-ui, sans-serif;
+    }
+    .sidebar-demo__col {
+      min-width: 0;
+    }
+    .sidebar-demo__label {
+      display: block;
+      font-size: 0.75rem;
+      font-weight: 600;
+      color: hsl(210 45% 35%);
+      margin-bottom: 0.4rem;
+    }
+    .sidebar-demo__panel {
+      background: hsl(0 0% 100%);
+      border: 1px solid hsl(210 20% 85%);
+      border-radius: 6px;
+      padding: 0.75rem;
+    }
+    .sidebar-demo__title {
+      font-size: 0.75rem;
+      font-weight: 600;
+      color: hsl(210 20% 40%);
+      margin-bottom: 0.35rem;
+    }
+    .sidebar-demo__code {
+      display: block;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 0.8rem;
+      line-height: 1.5;
+      color: hsl(210 20% 20%);
+      overflow-wrap: break-word;
+    }
+  `}
+/>
+
+## 区切り文字の集合
+
+`/` は第一の区切り文字です — URL、UNIXパス、パッケージ識別子をカバーします。検討に値する完全な集合は以下のとおりです。
+
+| 区切り文字 | なぜこの後に注入するか |
+|---|---|
+| `/` | 第一選択。URLのパスセグメント、UNIXパス、スコープ付きパッケージ名 |
+| `\` | Windowsパス (`C:\Users\Example\...`) |
+| `.` | ドット区切り識別子 (`com.example.app`)、ファイル名、ホスト名 |
+| `-` | ケバブケース識別子、長いスラッグ |
+| `_` | スネークケース識別子 |
+| `:` | ポート区切り (`host:8080`)、プロトコル (`https:`)、名前空間 (`ns:value`) |
+| `?` | クエリ文字列の境界 |
+| `#` | フラグメントの境界 |
+| `&` | クエリパラメータの区切り |
+| `=` | クエリのキー/値の境界 |
+
+`<wbr>` は区切り文字の **後** に注入し、前ではありません。区切り文字は前の行に残り、次のセグメントは次の行の先頭から始まります — 自然な読み順です。
+
+## `isPathLike` ゲート（本文ガード）
+
+ドキュメント中のすべての `/`、`.`、`-` の後に `<wbr>` を注入すると、通常の本文が破壊されます。
+
+- `and/or` が `and/<wbr>or` になる
+- `well-known` が `well-<wbr>known` になる
+- `state-of-the-art` が `state-<wbr>of-<wbr>the-<wbr>art` になる
+- `1.2.3-beta.4` は折り返し候補の紙吹雪になる
+- `UI/UX` が `UI/<wbr>UX` になる
+
+これらのトークンは1行に収まるのが普通なので、通常はレンダリングに変化は出ません — しかしそのトークンは以後、幅の狭いあらゆるコンテキストで折り返し候補になります。
+
+注入は **パス風（path-like）** チェックで制御します。トークンがパス風なのは、次のいずれかに見える場合です。
+
+- `/` を2つ以上含む (`/a/b/c`、`packages/widget/src`)
+- URLスキームで始まる (`https://`、`file://`、`ftp://`)
+- Windowsのドライブレターで始まる (`C:\`、`D:\Users\...`)
+- `?` の後に `=` を含む（クエリ文字列の形）
+
+そのままにすべき例:
+
+| トークン | パス風? |
+|---|---|
+| `and/or` | No — `/` が1つだけ、スキームなし |
+| `well-known` | No — `-` が1つだけ、スラッシュなし |
+| `state-of-the-art` | No — ダッシュのみ |
+| `1.2.3-beta.4` | No — バージョン文字列であってパスではない |
+| `UI/UX` | No — `/` が1つで、周りがすべて大文字 |
+| `/a/b/c/d/e` | Yes — `/` が3つ以上 |
+| `https://example.com/docs/guide` | Yes — スキームあり |
+| `C:\Users\Example\logs` | Yes — Windowsドライブ |
+| `?q=hello&lang=ja` | Yes — クエリ形 |
+
+<CssPreview client:load
+  title="D3 — isPathLike ゲート: 本文はそのまま、パスには折り返し候補を挿入"
+  height={380}
+  defaultOpen={false}
+  html={`
+    <div class="gate-demo">
+      <div class="gate-demo__col">
+        <span class="gate-demo__label">Prose — no injection</span>
+        <div class="gate-demo__panel">
+          <p>Options: <code>and/or</code>, <code>well-known</code>, <code>state-of-the-art</code>, <code>UI/UX</code>, version <code>1.2.3-beta.4</code>.</p>
+        </div>
+      </div>
+      <div class="gate-demo__col">
+        <span class="gate-demo__label">Paths — wbr injected</span>
+        <div class="gate-demo__panel">
+          <p>Path: <code>/a/<wbr>b/<wbr>c/<wbr>d/<wbr>e</code></p>
+          <p>URL: <code>https://<wbr>example.com/<wbr>docs/<wbr>guide</code></p>
+          <p>Win: <code>C:\\<wbr>Users\\<wbr>Example\\<wbr>logs</code></p>
+        </div>
+      </div>
+    </div>
+  `}
+  css={`
+    .gate-demo {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1rem;
+      padding: 1rem;
+      background: hsl(140 15% 97%);
+      font-family: system-ui, sans-serif;
+    }
+    .gate-demo__col {
+      min-width: 0;
+    }
+    .gate-demo__label {
+      display: block;
+      font-size: 0.75rem;
+      font-weight: 600;
+      color: hsl(140 35% 30%);
+      margin-bottom: 0.4rem;
+    }
+    .gate-demo__panel {
+      background: hsl(0 0% 100%);
+      border: 1px solid hsl(140 20% 85%);
+      border-radius: 6px;
+      padding: 0.75rem 1rem;
+      width: 240px;
+      max-width: 100%;
+    }
+    .gate-demo__panel p {
+      font-size: 0.85rem;
+      line-height: 1.55;
+      margin: 0 0 0.5rem;
+      color: hsl(140 15% 20%);
+    }
+    .gate-demo__panel p:last-child {
+      margin-bottom: 0;
+    }
+    .gate-demo__panel code {
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 0.8rem;
+      overflow-wrap: break-word;
+    }
+  `}
+/>
+
+トークンをパス風だと自信を持って分類できない場合は、注入しないでください。偽陰性（1つのトークンが狭いコンテナで折り返されないまま残る）のコストは、偽陽性（本文がどこでも不自然な位置で折り返される）のコストより大幅に低いです。
+
+## コンテナ側の CSS 調整
+
+`<wbr>` は折り返し位置の候補を提示するだけです。そこで実際にどうするかはコンテナのCSSが決めます。面によって望ましいコンテナルールは異なります。
+
+| コンテキスト | 推奨ルール | 理由 |
+|---|---|---|
+| 本文（段落、リスト項目、カード） | `overflow-wrap: break-word` | トークンがあふれる場合のみ `<wbr>` で折り返す。通常の単語はそのまま |
+| コードブロック (`<pre><code>`) | `white-space: pre-wrap` — 水平スクロールを受け入れるか、ユーザー切り替えモードとして `overflow-wrap: anywhere` を追加 | `pre-wrap` はインデントと改行を保持する。`pre-wrap` の中では、1つの長いトークンに対して `<wbr>` だけでは足りない |
+| Diffビューア（`+`/`-` カラム、狭いガター） | `word-break: break-all` | セルが隣接要素にあふれないほうが重要で、区切り文字を意識した折り返しよりも収めることが優先される |
+| 狭いflexパネル（サイドバー、チャットバブル） | `overflow-wrap: break-word` **かつ** flex子要素に `min-width: 0` | `min-width: 0` がないと、flexアイテムの `min-content` サイズは最長の単語に等しくなり、縮まなくなる |
+
+### 警告: 同じ要素で `word-break: break-all` と smart-break を混在させない
+
+`word-break: break-all` はブラウザに「任意の2文字の間で折り返してよい、以上」と伝えます。このルールが有効になると、ブラウザは行に収まる最初の文字位置で折り返し、`<wbr>` の折り返し候補ヒントを参照しなくなります。区切り文字を意識した注入は完全に無駄になります。要素ごとに戦略を1つだけ選んでください。区切り文字を意識した折り返しならsmart-break（`<wbr>` + `overflow-wrap: break-word`）を、diffセルのような「何としても収める」面なら `word-break: break-all` を使います。両方を併用してはいけません。
+
+### 警告: フェンスコードに `white-space: pre-wrap` を使うと `overflow-wrap: break-word` が効かなくなる
+
+`white-space: pre-wrap` はリテラルな空白と改行を保持します。コードブロックに望ましい挙動です。副作用として、長い一塊のトークン（ログ行の中の180文字のURLなど）が `overflow-wrap: break-word` に応答しなくなります — このルールは必要なときにのみ折り返す仕様であり、`pre-wrap` のもとではトークンは自前のオーバーフロースクロールする行に技術的には「収まって」しまうからです。コードブロックには2つの選択肢があります。
+
+- 水平スクロールを受け入れる。コードはバイト正確なまま、ユーザーがスクロールします。
+- 明示的なオプトインモードとして `overflow-wrap: anywhere` を提供する（`break-word` より強く、必要ならトークンの途中でも折り返す）。これはユーザー切り替え可能なクラスに限定し、デフォルトにしないでください。
+
+コードブロックに `word-break: break-all` を持ち出してはいけません — 1行ごとに識別子の途中でコードが粉々になります。
+
+<CssPreview client:load
+  title="D5 — 同じ注入済みコンテンツに対する overflow-wrap: break-word と anywhere"
+  height={380}
+  defaultOpen={false}
+  html={`
+    <div class="break-demo">
+      <div class="break-demo__col">
+        <span class="break-demo__label">overflow-wrap: break-word</span>
+        <div class="break-demo__panel break-demo__panel--word">
+          <code>https://<wbr>example.com/<wbr>docs/<wbr>guide/<wbr>verylongsegmentwithnodelimitersanywhere</code>
+        </div>
+        <p class="break-demo__note">Respects delimiter hints first. Only breaks mid-token if a single segment would still overflow.</p>
+      </div>
+      <div class="break-demo__col">
+        <span class="break-demo__label">overflow-wrap: anywhere</span>
+        <div class="break-demo__panel break-demo__panel--any">
+          <code>https://<wbr>example.com/<wbr>docs/<wbr>guide/<wbr>verylongsegmentwithnodelimitersanywhere</code>
+        </div>
+        <p class="break-demo__note">Can break anywhere if it produces a shorter min-content. Segments get chopped even when delimiters would have fit.</p>
+      </div>
+    </div>
+  `}
+  css={`
+    .break-demo {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1rem;
+      padding: 1rem;
+      background: hsl(260 15% 97%);
+      font-family: system-ui, sans-serif;
+    }
+    .break-demo__col {
+      min-width: 0;
+    }
+    .break-demo__label {
+      display: block;
+      font-size: 0.75rem;
+      font-weight: 600;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      color: hsl(260 40% 35%);
+      margin-bottom: 0.4rem;
+    }
+    .break-demo__panel {
+      width: 240px;
+      max-width: 100%;
+      background: hsl(0 0% 100%);
+      border: 1px solid hsl(260 20% 85%);
+      border-radius: 6px;
+      padding: 0.6rem 0.75rem;
+    }
+    .break-demo__panel code {
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 0.8rem;
+      line-height: 1.5;
+      color: hsl(260 20% 20%);
+    }
+    .break-demo__panel--word code {
+      overflow-wrap: break-word;
+    }
+    .break-demo__panel--any code {
+      overflow-wrap: anywhere;
+    }
+    .break-demo__note {
+      font-size: 0.75rem;
+      line-height: 1.5;
+      color: hsl(260 15% 35%);
+      margin: 0.5rem 0 0;
+    }
+  `}
+/>
+
+`break-word` は、単一セグメント自体があふれるまではセグメントを壊しません — そのため区切り文字付きのURLは `/`、`?`、`&` できれいに折り返されます。`anywhere` はもっと積極的です。`min-content` 幅に寄与するので、flex親要素が最長セグメントより狭くなることが許されます。`anywhere` を使うのは、`break-word` では不十分（1つのセグメントがコンテナより長い）で、識別子の途中で折り返すことを受け入れられるときだけにしてください。
+
+## ゼロ幅スペース (U+200B) — テキスト専用のフォールバック
+
+`U+200B`（ゼロ幅スペース、`&#8203;` とも書く）は文字列の中に折り返し候補を挿入する文字です。これは `<wbr>` と同等の推奨手段 **ではありません**。HTMLが使えない場面 — 長い文字列が要素を含められないプレーンテキスト面に存在しなければならないとき — にのみ使います。
+
+HTMLを出力できない面:
+
+- `title` 属性の値（ブラウザのツールチップテキスト）
+- `aria-label` の値
+- HTMLを解釈しないコンポーネントに渡されるプレーンなJSON文字列
+- 表示時にそれでも折り返さなければならないCSVやテキストファイルのエクスポート
+
+`<wbr>` と比較したトレードオフ:
+
+- **クリップボードの汚染。** `U+200B` は実在する文字です。選択と一緒にコピーされ、貼り付け先にそのまま貼り付けられます。ゼロ幅スペースを含むURLを端末やURLフィールドに貼り付けると、検出しづらい失敗が起こることがあります。
+- **文字列長の歪み。** `"hello".length` と `"hel​lo".length` — 後者は6になります。バリデータ、diffツール、バイト数UIは、ユーザーが見ているものとは異なる値を報告します。
+- **アクセシビリティ保証が弱い。** スクリーンリーダーはたいてい無視しますが、リーダーやバージョンによって挙動が異なります。`<wbr>` には「読み上げない」という明文化された契約があります。
+- **キャレットの挙動。** `U+200B` をナビゲート可能な文字として扱うエディタもあります。矢印キーでの移動中にキャレットがそこで止まることがあります。
+
+経験則としては、HTMLを出力できるなら `<wbr>` を使ってください。`U+200B` はテキスト専用面にのみ使います。次のメンテナが単純な文字列に戻して折り返し能力を失わないように、コードコメントに判断の理由を記録しておきましょう。
+
+<CssPreview client:load
+  title="D4 — U+200B によるプレーンテキスト面での折り返し"
+  height={260}
+  defaultOpen={false}
+  html={`
+    <div class="zwsp-demo">
+      <div class="zwsp-demo__col">
+        <span class="zwsp-demo__label">Plain string — no break opportunity</span>
+        <div class="zwsp-demo__panel">https://example.com/docs/guide/section?q=hello&lang=ja</div>
+      </div>
+      <div class="zwsp-demo__col">
+        <span class="zwsp-demo__label">Same string with U+200B after each delimiter</span>
+        <div class="zwsp-demo__panel">https://&#8203;example.com/&#8203;docs/&#8203;guide/&#8203;section?&#8203;q=hello&amp;&#8203;lang=ja</div>
+      </div>
+    </div>
+  `}
+  css={`
+    .zwsp-demo {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1rem;
+      padding: 1rem;
+      background: hsl(40 25% 97%);
+      font-family: system-ui, sans-serif;
+    }
+    .zwsp-demo__col {
+      min-width: 0;
+    }
+    .zwsp-demo__label {
+      display: block;
+      font-size: 0.75rem;
+      font-weight: 600;
+      color: hsl(40 50% 30%);
+      margin-bottom: 0.4rem;
+    }
+    .zwsp-demo__panel {
+      width: 240px;
+      max-width: 100%;
+      background: hsl(0 0% 100%);
+      border: 1px solid hsl(40 30% 85%);
+      border-radius: 6px;
+      padding: 0.6rem 0.75rem;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 0.8rem;
+      line-height: 1.5;
+      color: hsl(40 20% 20%);
+      overflow-wrap: break-word;
+    }
+  `}
+/>
+
+左のパネルはあふれるか、きれいに折り返されません。右のパネルは挿入された `U+200B` の位置で折り返されます — `<wbr>` と同じ見た目ですが、コピー&ペーストに不可視文字が持ち運ばれます。
+
+HTMLが使える場面では常に `<wbr>` を使ってください。
+
+## AIがよくやるミス
+
+- `word-break: break-all` を一律ルールとして持ち出す。目の前の狭いコンテナは1つ修正できますが、サイト全体の段落やコードブロックをそっと台無しにします。
+- flex子要素に `min-width: 0` を付け忘れる。flexアイテムのデフォルトの `min-width: auto` は `min-content` に等しく、これは最も長い単語です。flexカラム内の長いURLは縮まなくなり、行全体をオーバーフローさせます。子要素に `min-width: 0` を付ければ解放されます。
+- `isPathLike` ゲートなしに `<wbr>` をグローバルに注入する。`and/or`、`state-of-the-art`、`1.2.3-beta.4` のような本文中のトークンが、本来なるべきでない折り返し候補になります。
+- `U+200B` と `<wbr>` を同じものとして扱う。`<wbr>` はHTMLのみ、`U+200B` は文字列中の文字です。コピー&ペーストや文字列長への影響は異なります。
+- 同じ要素でsmart-breakと `word-break: break-all` を混ぜる。`break-all` は `<wbr>` のヒントを無視するので、区切り文字を意識した注入は無駄な作業になります。
+- `<pre>` や `<code>` ブロックに `overflow-wrap: break-word` を当てて、長いトークンが折り返されることを期待する。これらの要素にはすでに `white-space: pre-wrap` が効いていて、単一の長いトークンに対しては `break-word` を無効化します。スクロールを受け入れるか、明示的に `overflow-wrap: anywhere` にオプトインしてください。
+
+## 使い分け
+
+### smart-break（`<wbr>` + `overflow-wrap: break-word`）を使うべき場面
+
+パス風のトークンを含む本文面: サイドバー、カード、チャットバブル、長い識別子カラムを持つテーブル、エラーメッセージパネル、コールアウト。注入は `isPathLike` で制御します。ユーザー生成やシステム生成のURLやファイルパスをレンダリングするあらゆるUIにとって、これがデフォルトです。
+
+### U+200B を使うべき場面
+
+HTMLを出力できないテキスト専用の面: `title` 属性、`aria-label` の値、HTMLを解釈しないコンポーネントに渡されるプレーン文字列のJSONフィールド。HTMLが使える場所ではどこでも `<wbr>` を優先します。将来のメンテナが意図を理解できるよう、呼び出し箇所で選択理由を記録してください。
+
+### スクロールや pre-wrap のままにしておくべき場面（コードとdiff）
+
+バイト正確さが重要なコードブロックでは、人為的な折り返し候補より水平スクロールを優先してください。「長い行を折り返す」オプトインのトグルを用意し、`overflow-wrap: anywhere` に切り替えるようにします。狭いガターを持つdiffビューアでは、区切り文字を意識した折り返しより列に収めることが重要なので、セル内容に `word-break: break-all` が必要になる場合があります。
+
+## 参考
+
+- [MDN: `<wbr>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/wbr)
+- [MDN: `overflow-wrap`](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap)
+- [MDN: `word-break`](https://developer.mozilla.org/en-US/docs/Web/CSS/word-break)
+- [MDN: `hyphens`](https://developer.mozilla.org/en-US/docs/Web/CSS/hyphens)
+- [Wikipedia: Zero-width space (U+200B)](https://en.wikipedia.org/wiki/Zero-width_space)
+
+`isPathLike` ゲートを備えた `<wbr>` 注入戦略の参考実装は zudo-doc に記録されています（エピック zudolab/zudo-doc#370、PR zudolab/zudo-doc#383）。

--- a/src/content/docs/typography/text-control/long-url-and-path-wrapping.mdx
+++ b/src/content/docs/typography/text-control/long-url-and-path-wrapping.mdx
@@ -29,7 +29,7 @@ Each of these properties has a use, but none of them is a general-purpose soluti
 | `word-break: break-all` | Breaks between any two characters, anywhere | Shreds prose mid-word; ignores delimiters; makes the rest of the page unreadable |
 | `overflow-wrap: anywhere` | Same effect, but only kicks in when the word would otherwise overflow | Still delimiter-blind; a long word breaks at an arbitrary character rather than at `/` or `?` |
 | `hyphens: auto` | Inserts soft hyphens at dictionary-derived points | Does nothing for URLs or paths — they are not dictionary words |
-| `word-break: break-word` | Legacy alias for `overflow-wrap: break-word` | Non-standard spelling; same behavior as `overflow-wrap: break-word`; prefer the standard form |
+| `word-break: break-word` | Legacy non-standard Chrome value; breaks more aggressively — roughly equivalent to `word-break: normal` plus `overflow-wrap: anywhere` | Not a synonym for `overflow-wrap: break-word`; its emergency breaking is as aggressive as `anywhere` and just as delimiter-blind; avoid — use one of the standard properties above |
 
 The correct answer for a URL like `https://example.com/docs/a/b/c` is almost always "break after `/`." The correct answer for a path like `C:\Users\Example` is "break after `\`." None of the properties above know this.
 

--- a/src/content/docs/typography/text-control/long-url-and-path-wrapping.mdx
+++ b/src/content/docs/typography/text-control/long-url-and-path-wrapping.mdx
@@ -1,0 +1,531 @@
+---
+title: Long URL and Path Wrapping
+description: Break long URLs, file paths, and package identifiers at delimiter-aware points without corrupting prose or code.
+sidebar_position: 5
+---
+
+import CssPreview from '@/components/CssPreview';
+
+## The Problem
+
+Narrow containers — sidebars, tables, chat bubbles, callout boxes — routinely receive long unbroken tokens that the browser has no idea how to wrap:
+
+```text
+@scope/org-name/packages/feature-module/src/components/widget.tsx
+https://example.com/docs/guide/section?utm_source=newsletter&utm_medium=email&utm_campaign=launch
+C:\Users\Example\AppData\Local\Temp\build-artifact-2026-04-24.log
+```
+
+By default, browsers treat each of these as a single word. The token blows past the container edge, forces a horizontal scrollbar on the whole layout, or spills into neighboring columns. AI agents reach for `word-break: break-all` or `overflow-wrap: anywhere`, ship the fix, and then get bug reports a week later: every paragraph is now breaking at random mid-word positions, and the prose is unreadable.
+
+The real problem is that the browser does not know which tokens are URL-like and which are prose. A blanket rule fixes the narrow-container case at the cost of everything else on the page.
+
+## Why the One-Liners Fall Short
+
+Each of these properties has a use, but none of them is a general-purpose solution:
+
+| Property | What it does | Why it isn't the answer |
+|---|---|---|
+| `word-break: break-all` | Breaks between any two characters, anywhere | Shreds prose mid-word; ignores delimiters; makes the rest of the page unreadable |
+| `overflow-wrap: anywhere` | Same effect, but only kicks in when the word would otherwise overflow | Still delimiter-blind; a long word breaks at an arbitrary character rather than at `/` or `?` |
+| `hyphens: auto` | Inserts soft hyphens at dictionary-derived points | Does nothing for URLs or paths — they are not dictionary words |
+| `word-break: break-word` | Legacy alias for `overflow-wrap: break-word` | Non-standard spelling; same behavior as `overflow-wrap: break-word`; prefer the standard form |
+
+The correct answer for a URL like `https://example.com/docs/a/b/c` is almost always "break after `/`." The correct answer for a path like `C:\Users\Example` is "break after `\`." None of the properties above know this.
+
+## The `<wbr>` Injection Strategy
+
+`<wbr>` is the **word break opportunity** element. It tells the browser "if you need to wrap here, this is a fine place to do it." When no wrap is needed, it produces zero visual output.
+
+Verified properties of `<wbr>`:
+
+- No glyph rendered — it takes up no visual space
+- Not announced by screen readers — no a11y noise
+- Not copied to the clipboard — the user selects the URL and gets the original string back
+- The caret behaves normally during selection — no off-by-one cursor jumps
+- SSR-safe — just HTML, no client-side JavaScript required
+
+The strategy is: find delimiter characters in URL-like tokens and inject a `<wbr>` **after** each one. The rendered string is byte-identical when copied. The token wraps at meaningful boundaries instead of at random character positions.
+
+Before:
+
+```html
+<code>@scope/org-name/packages/feature-module/src/widget.tsx</code>
+```
+
+After:
+
+```html
+<code>@scope/<wbr>org-name/<wbr>packages/<wbr>feature-module/<wbr>src/<wbr>widget.tsx</code>
+```
+
+<CssPreview client:load
+  title="D1 — Four wrapping strategies in a 240px column"
+  height={520}
+  defaultOpen={false}
+  html={`
+    <div class="wrap-demo">
+      <div class="wrap-demo__col">
+        <span class="wrap-demo__label">plain (no wrap rule)</span>
+        <div class="wrap-demo__cell wrap-demo__cell--plain">
+          https://example.com/docs/guide/section?utm_source=newsletter&utm_medium=email
+        </div>
+      </div>
+      <div class="wrap-demo__col">
+        <span class="wrap-demo__label">word-break: break-all</span>
+        <div class="wrap-demo__cell wrap-demo__cell--all">
+          https://example.com/docs/guide/section?utm_source=newsletter&utm_medium=email
+        </div>
+      </div>
+      <div class="wrap-demo__col">
+        <span class="wrap-demo__label">overflow-wrap: anywhere</span>
+        <div class="wrap-demo__cell wrap-demo__cell--anywhere">
+          https://example.com/docs/guide/section?utm_source=newsletter&utm_medium=email
+        </div>
+      </div>
+      <div class="wrap-demo__col">
+        <span class="wrap-demo__label">smart-break (wbr + overflow-wrap: break-word)</span>
+        <div class="wrap-demo__cell wrap-demo__cell--smart">
+          https://<wbr>example.com/<wbr>docs/<wbr>guide/<wbr>section?<wbr>utm_source=<wbr>newsletter&<wbr>utm_medium=<wbr>email
+        </div>
+      </div>
+    </div>
+  `}
+  css={`
+    .wrap-demo {
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+      padding: 1rem;
+      background: hsl(30 20% 97%);
+      font-family: system-ui, sans-serif;
+    }
+    .wrap-demo__col {
+      width: 240px;
+      max-width: 100%;
+    }
+    .wrap-demo__label {
+      display: block;
+      font-size: 0.75rem;
+      font-weight: 600;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      color: hsl(30 40% 30%);
+      margin-bottom: 0.35rem;
+    }
+    .wrap-demo__cell {
+      width: 240px;
+      padding: 0.6rem 0.75rem;
+      border: 1px solid hsl(30 20% 80%);
+      border-radius: 6px;
+      background: hsl(0 0% 100%);
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 0.8rem;
+      line-height: 1.5;
+      color: hsl(30 20% 20%);
+    }
+    .wrap-demo__cell--plain {
+      white-space: nowrap;
+      overflow-x: auto;
+    }
+    .wrap-demo__cell--all {
+      word-break: break-all;
+    }
+    .wrap-demo__cell--anywhere {
+      overflow-wrap: anywhere;
+    }
+    .wrap-demo__cell--smart {
+      overflow-wrap: break-word;
+    }
+  `}
+/>
+
+The `plain` cell overflows horizontally. `break-all` wraps at arbitrary character positions — the URL is unreadable. `anywhere` wraps at similar arbitrary positions but only when overflow would occur. `smart-break` wraps cleanly after each `/`, `?`, and `&`.
+
+<CssPreview client:load
+  title="D2 — Same path with and without wbr injection in a narrow sidebar"
+  height={340}
+  defaultOpen={false}
+  html={`
+    <div class="sidebar-demo">
+      <div class="sidebar-demo__col">
+        <span class="sidebar-demo__label">No injection</span>
+        <div class="sidebar-demo__panel">
+          <div class="sidebar-demo__title">File:</div>
+          <code class="sidebar-demo__code">@scope/org-name/packages/feature-module/src/components/widget.tsx</code>
+        </div>
+      </div>
+      <div class="sidebar-demo__col">
+        <span class="sidebar-demo__label">wbr injected after each /</span>
+        <div class="sidebar-demo__panel">
+          <div class="sidebar-demo__title">File:</div>
+          <code class="sidebar-demo__code">@scope/<wbr>org-name/<wbr>packages/<wbr>feature-module/<wbr>src/<wbr>components/<wbr>widget.tsx</code>
+        </div>
+      </div>
+    </div>
+  `}
+  css={`
+    .sidebar-demo {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1rem;
+      padding: 1rem;
+      background: hsl(210 20% 97%);
+      font-family: system-ui, sans-serif;
+    }
+    .sidebar-demo__col {
+      min-width: 0;
+    }
+    .sidebar-demo__label {
+      display: block;
+      font-size: 0.75rem;
+      font-weight: 600;
+      color: hsl(210 45% 35%);
+      margin-bottom: 0.4rem;
+    }
+    .sidebar-demo__panel {
+      background: hsl(0 0% 100%);
+      border: 1px solid hsl(210 20% 85%);
+      border-radius: 6px;
+      padding: 0.75rem;
+    }
+    .sidebar-demo__title {
+      font-size: 0.75rem;
+      font-weight: 600;
+      color: hsl(210 20% 40%);
+      margin-bottom: 0.35rem;
+    }
+    .sidebar-demo__code {
+      display: block;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 0.8rem;
+      line-height: 1.5;
+      color: hsl(210 20% 20%);
+      overflow-wrap: break-word;
+    }
+  `}
+/>
+
+## Delimiter Set
+
+`/` is the primary delimiter — it covers URLs, UNIX paths, and package identifiers. The full set worth considering:
+
+| Delimiter | Why inject after it |
+|---|---|
+| `/` | Primary. URL path segments, UNIX paths, scoped package names |
+| `\` | Windows paths (`C:\Users\Example\...`) |
+| `.` | Dotted identifiers (`com.example.app`), filenames, hostnames |
+| `-` | Kebab-case identifiers, long slugs |
+| `_` | snake_case identifiers |
+| `:` | Port separators (`host:8080`), protocol (`https:`), namespace (`ns:value`) |
+| `?` | Query-string boundary |
+| `#` | Fragment boundary |
+| `&` | Query-parameter separator |
+| `=` | Query key/value boundary |
+
+Inject the `<wbr>` **after** the delimiter, not before. The delimiter stays on the preceding line, and the next segment starts the following line — the natural reading order.
+
+## The `isPathLike` Gate (Prose Guard)
+
+Injecting `<wbr>` after every `/`, `.`, and `-` in a document corrupts normal prose:
+
+- `and/or` becomes `and/<wbr>or`
+- `well-known` becomes `well-<wbr>known`
+- `state-of-the-art` becomes `state-<wbr>of-<wbr>the-<wbr>art`
+- `1.2.3-beta.4` becomes a confetti of breakpoints
+- `UI/UX` becomes `UI/<wbr>UX`
+
+The rendering is usually unchanged because these tokens fit on one line — but the token is now a break-candidate in every narrow context downstream.
+
+Gate injection on a **path-like** check. A token is path-like when it looks like one of:
+
+- Contains two or more `/` characters (`/a/b/c`, `packages/widget/src`)
+- Starts with a URL scheme (`https://`, `file://`, `ftp://`)
+- Starts with a Windows drive letter (`C:\`, `D:\Users\...`)
+- Contains `?` followed by `=` (query string shape)
+
+Examples that must remain untouched:
+
+| Token | Path-like? |
+|---|---|
+| `and/or` | No — only one `/`, no scheme |
+| `well-known` | No — single `-`, no slashes |
+| `state-of-the-art` | No — dashes only |
+| `1.2.3-beta.4` | No — version string, not a path |
+| `UI/UX` | No — single `/` with all-caps around it |
+| `/a/b/c/d/e` | Yes — three or more `/` |
+| `https://example.com/docs/guide` | Yes — scheme present |
+| `C:\Users\Example\logs` | Yes — Windows drive |
+| `?q=hello&lang=ja` | Yes — query shape |
+
+<CssPreview client:load
+  title="D3 — isPathLike gate: prose stays whole, paths get break opportunities"
+  height={380}
+  defaultOpen={false}
+  html={`
+    <div class="gate-demo">
+      <div class="gate-demo__col">
+        <span class="gate-demo__label">Prose — no injection</span>
+        <div class="gate-demo__panel">
+          <p>Options: <code>and/or</code>, <code>well-known</code>, <code>state-of-the-art</code>, <code>UI/UX</code>, version <code>1.2.3-beta.4</code>.</p>
+        </div>
+      </div>
+      <div class="gate-demo__col">
+        <span class="gate-demo__label">Paths — wbr injected</span>
+        <div class="gate-demo__panel">
+          <p>Path: <code>/a/<wbr>b/<wbr>c/<wbr>d/<wbr>e</code></p>
+          <p>URL: <code>https://<wbr>example.com/<wbr>docs/<wbr>guide</code></p>
+          <p>Win: <code>C:\\<wbr>Users\\<wbr>Example\\<wbr>logs</code></p>
+        </div>
+      </div>
+    </div>
+  `}
+  css={`
+    .gate-demo {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1rem;
+      padding: 1rem;
+      background: hsl(140 15% 97%);
+      font-family: system-ui, sans-serif;
+    }
+    .gate-demo__col {
+      min-width: 0;
+    }
+    .gate-demo__label {
+      display: block;
+      font-size: 0.75rem;
+      font-weight: 600;
+      color: hsl(140 35% 30%);
+      margin-bottom: 0.4rem;
+    }
+    .gate-demo__panel {
+      background: hsl(0 0% 100%);
+      border: 1px solid hsl(140 20% 85%);
+      border-radius: 6px;
+      padding: 0.75rem 1rem;
+      width: 240px;
+      max-width: 100%;
+    }
+    .gate-demo__panel p {
+      font-size: 0.85rem;
+      line-height: 1.55;
+      margin: 0 0 0.5rem;
+      color: hsl(140 15% 20%);
+    }
+    .gate-demo__panel p:last-child {
+      margin-bottom: 0;
+    }
+    .gate-demo__panel code {
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 0.8rem;
+      overflow-wrap: break-word;
+    }
+  `}
+/>
+
+If you cannot confidently classify a token as path-like, do not inject. The cost of a false negative (one token stays unwrapped in a narrow container) is much lower than the cost of a false positive (prose breaks at unnatural points everywhere).
+
+## Container CSS Tuning
+
+`<wbr>` only proposes break points. The container's CSS decides what to do with them. Different surfaces want different container rules.
+
+| Context | Recommended rule | Why |
+|---|---|---|
+| Prose (paragraphs, list items, cards) | `overflow-wrap: break-word` | Breaks at `<wbr>` when the token would overflow; leaves ordinary words intact |
+| Code blocks (`<pre><code>`) | `white-space: pre-wrap` — accept horizontal scroll, or add `overflow-wrap: anywhere` as a user-toggled mode | `pre-wrap` preserves indentation and newlines; `<wbr>` is not enough for unbroken tokens inside `pre-wrap` |
+| Diff viewers (`+`/`-` columns, narrow gutters) | `word-break: break-all` | Cells must not overflow into siblings; delimiter-aware breaking is less important than fitting |
+| Narrow flex panels (sidebars, chat bubbles) | `overflow-wrap: break-word` **plus** `min-width: 0` on flex children | Without `min-width: 0`, a flex item's `min-content` size equals its longest word, and the item refuses to shrink |
+
+### Warning: do not mix `word-break: break-all` with smart-break on the same element
+
+`word-break: break-all` tells the browser "you may break between any two characters, period." Once that rule is active, the browser breaks at whatever character position fits the line first — it never consults the `<wbr>` break-opportunity hints. The delimiter-aware injection is fully defeated. Pick one strategy per element: either smart-break (`<wbr>` + `overflow-wrap: break-word`) for delimiter-aware breaks, or `word-break: break-all` for "fit at all costs" surfaces like diff cells. Never both.
+
+### Warning: `white-space: pre-wrap` on fenced code defeats `overflow-wrap: break-word`
+
+`white-space: pre-wrap` preserves literal whitespace and newlines, which is what you want for code blocks. The side effect is that long unbroken tokens (a 180-character URL inside a log line) no longer respond to `overflow-wrap: break-word` — the rule is specified to only break when needed, and `pre-wrap` makes the token technically "fit" on its own overflow-scrolling line. You have two choices for code blocks:
+
+- Accept horizontal scroll. The code stays byte-accurate; the user scrolls.
+- Offer an explicit opt-in mode that sets `overflow-wrap: anywhere` (stronger than `break-word`; will break mid-token if needed). Scope this to a user-toggled class so it does not become the default.
+
+Do not reach for `word-break: break-all` on code blocks — it shreds the code mid-identifier on every line.
+
+<CssPreview client:load
+  title="D5 — overflow-wrap: break-word vs anywhere on the same injected content"
+  height={380}
+  defaultOpen={false}
+  html={`
+    <div class="break-demo">
+      <div class="break-demo__col">
+        <span class="break-demo__label">overflow-wrap: break-word</span>
+        <div class="break-demo__panel break-demo__panel--word">
+          <code>https://<wbr>example.com/<wbr>docs/<wbr>guide/<wbr>verylongsegmentwithnodelimitersanywhere</code>
+        </div>
+        <p class="break-demo__note">Respects delimiter hints first. Only breaks mid-token if a single segment would still overflow.</p>
+      </div>
+      <div class="break-demo__col">
+        <span class="break-demo__label">overflow-wrap: anywhere</span>
+        <div class="break-demo__panel break-demo__panel--any">
+          <code>https://<wbr>example.com/<wbr>docs/<wbr>guide/<wbr>verylongsegmentwithnodelimitersanywhere</code>
+        </div>
+        <p class="break-demo__note">Can break anywhere if it produces a shorter min-content. Segments get chopped even when delimiters would have fit.</p>
+      </div>
+    </div>
+  `}
+  css={`
+    .break-demo {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1rem;
+      padding: 1rem;
+      background: hsl(260 15% 97%);
+      font-family: system-ui, sans-serif;
+    }
+    .break-demo__col {
+      min-width: 0;
+    }
+    .break-demo__label {
+      display: block;
+      font-size: 0.75rem;
+      font-weight: 600;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      color: hsl(260 40% 35%);
+      margin-bottom: 0.4rem;
+    }
+    .break-demo__panel {
+      width: 240px;
+      max-width: 100%;
+      background: hsl(0 0% 100%);
+      border: 1px solid hsl(260 20% 85%);
+      border-radius: 6px;
+      padding: 0.6rem 0.75rem;
+    }
+    .break-demo__panel code {
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 0.8rem;
+      line-height: 1.5;
+      color: hsl(260 20% 20%);
+    }
+    .break-demo__panel--word code {
+      overflow-wrap: break-word;
+    }
+    .break-demo__panel--any code {
+      overflow-wrap: anywhere;
+    }
+    .break-demo__note {
+      font-size: 0.75rem;
+      line-height: 1.5;
+      color: hsl(260 15% 35%);
+      margin: 0.5rem 0 0;
+    }
+  `}
+/>
+
+`break-word` keeps segments intact until a single segment would itself overflow — so delimited URLs wrap cleanly at `/`, `?`, and `&`. `anywhere` is more aggressive: it contributes to `min-content` width, so a flex parent is allowed to shrink below the longest segment. Use `anywhere` only when `break-word` is not enough (a single segment is longer than the container) and you are willing to break mid-identifier.
+
+## Zero-Width Space (U+200B) — Text-Only Fallback
+
+`U+200B` (zero-width space, also written `&#8203;`) is a character that introduces a break opportunity inside a string. It is **not** a peer recommendation to `<wbr>`. Use it only when HTML is not available — when the long string must live inside a plain-text surface that cannot contain elements.
+
+Surfaces where HTML cannot be emitted:
+
+- `title` attribute values (browser tooltip text)
+- `aria-label` values
+- Plain JSON strings handed to a component that does not interpret HTML
+- CSV or text-file exports that must still wrap when displayed
+
+Trade-offs vs `<wbr>`:
+
+- **Clipboard pollution.** `U+200B` is a real character. It is copied with the selection and pasted into the destination. Pasting a URL that contains zero-width spaces into a terminal or a URL field can fail in subtle ways.
+- **String-length distortion.** `"hello".length` vs `"hel​lo".length` — the second is 6. Validators, diff tools, and byte-count UIs will report different values than the user sees.
+- **Weaker a11y guarantee.** Screen readers mostly ignore it, but behavior varies by reader and version. `<wbr>` has a well-specified "no announcement" contract.
+- **Caret behavior.** Some editors treat `U+200B` as a navigable character; the caret may stop there during arrow-key navigation.
+
+Rule of thumb: if you can emit HTML, use `<wbr>`. Reach for `U+200B` only for text-only surfaces. Document the decision in code comments so the next maintainer does not swap it back to a plain string and lose the wrapping.
+
+<CssPreview client:load
+  title="D4 — U+200B wraps inside a plain-text surface"
+  height={260}
+  defaultOpen={false}
+  html={`
+    <div class="zwsp-demo">
+      <div class="zwsp-demo__col">
+        <span class="zwsp-demo__label">Plain string — no break opportunity</span>
+        <div class="zwsp-demo__panel">https://example.com/docs/guide/section?q=hello&lang=ja</div>
+      </div>
+      <div class="zwsp-demo__col">
+        <span class="zwsp-demo__label">Same string with U+200B after each delimiter</span>
+        <div class="zwsp-demo__panel">https://&#8203;example.com/&#8203;docs/&#8203;guide/&#8203;section?&#8203;q=hello&amp;&#8203;lang=ja</div>
+      </div>
+    </div>
+  `}
+  css={`
+    .zwsp-demo {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1rem;
+      padding: 1rem;
+      background: hsl(40 25% 97%);
+      font-family: system-ui, sans-serif;
+    }
+    .zwsp-demo__col {
+      min-width: 0;
+    }
+    .zwsp-demo__label {
+      display: block;
+      font-size: 0.75rem;
+      font-weight: 600;
+      color: hsl(40 50% 30%);
+      margin-bottom: 0.4rem;
+    }
+    .zwsp-demo__panel {
+      width: 240px;
+      max-width: 100%;
+      background: hsl(0 0% 100%);
+      border: 1px solid hsl(40 30% 85%);
+      border-radius: 6px;
+      padding: 0.6rem 0.75rem;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 0.8rem;
+      line-height: 1.5;
+      color: hsl(40 20% 20%);
+      overflow-wrap: break-word;
+    }
+  `}
+/>
+
+The left panel overflows or fails to wrap cleanly. The right panel wraps at the injected `U+200B` positions — same visual result as `<wbr>`, but copy-paste now carries the invisible characters.
+
+Use `<wbr>` whenever HTML is available.
+
+## Common AI Mistakes
+
+- Reaching for `word-break: break-all` as a blanket rule. It fixes the one narrow container in front of you and quietly ruins every paragraph and code block on the rest of the site.
+- Forgetting `min-width: 0` on flex children. A flex item's default `min-width: auto` equals `min-content`, which is the widest word. A long URL in a flex column refuses to shrink, forcing the whole row to overflow. Setting `min-width: 0` on the child unsticks it.
+- Injecting `<wbr>` globally without an `isPathLike` gate. Prose tokens like `and/or`, `state-of-the-art`, and `1.2.3-beta.4` become wrap candidates they should never be.
+- Treating `U+200B` and `<wbr>` as interchangeable. `<wbr>` is HTML-only; `U+200B` is a character in the string. The copy-paste and string-length implications are different.
+- Mixing smart-break with `word-break: break-all` on the same element. `break-all` ignores `<wbr>` hints — the delimiter-aware injection is wasted work.
+- Applying `overflow-wrap: break-word` to a `<pre>` or `<code>` block and expecting long tokens to wrap. `white-space: pre-wrap` is already in effect for those elements, and it neutralizes `break-word` for single long tokens. Accept scroll, or opt in to `overflow-wrap: anywhere` explicitly.
+
+## When to Use
+
+### When to smart-break (`<wbr>` + `overflow-wrap: break-word`)
+
+Prose surfaces that contain path-like tokens: sidebars, cards, chat bubbles, tables with long-identifier columns, error-message panels, callouts. Gate injection on `isPathLike`. This is the default for any UI that renders user- or system-generated URLs and file paths.
+
+### When to use U+200B
+
+Text-only surfaces where HTML cannot be emitted: `title` attributes, `aria-label` values, plain-string JSON fields consumed by non-HTML-aware components. Prefer `<wbr>` everywhere HTML is available. Document the choice at the call site so future maintainers understand the intent.
+
+### When to leave it as scrolling or pre-wrap (code and diffs)
+
+Code blocks where byte accuracy matters — prefer horizontal scroll to synthetic break opportunities. Offer an opt-in "wrap long lines" toggle that switches on `overflow-wrap: anywhere`. Diff viewers with narrow gutters may need `word-break: break-all` on the cell content because fitting the column is more important than delimiter-aware breaking.
+
+## References
+
+- [MDN: `<wbr>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/wbr)
+- [MDN: `overflow-wrap`](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap)
+- [MDN: `word-break`](https://developer.mozilla.org/en-US/docs/Web/CSS/word-break)
+- [MDN: `hyphens`](https://developer.mozilla.org/en-US/docs/Web/CSS/hyphens)
+- [Wikipedia: Zero-width space (U+200B)](https://en.wikipedia.org/wiki/Zero-width_space)
+
+A reference implementation of the `<wbr>`-injection strategy with an `isPathLike` gate is tracked in zudo-doc (epic zudolab/zudo-doc#370, PR zudolab/zudo-doc#383).


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-css-wisdom/issues/42

---

## Summary

- Adds a new article at `typography/text-control/long-url-and-path-wrapping.mdx` (EN + JA) covering the technique of wrapping long URL-like / path-like tokens at delimiter boundaries (`/`, `-`, `.`, etc.) using `<wbr>` injection plus `overflow-wrap: break-word`.
- Contrasts the technique with the usual one-liners (`word-break: break-all`, `overflow-wrap: anywhere`, `hyphens: auto`, `word-break: break-word`) and explains when each is wrong.
- Covers the `U+200B` zero-width-space fallback for text-only surfaces (explicitly framed as a fallback, not a peer recommendation to `<wbr>`).
- Documents the `isPathLike` heuristic that gates injection so prose ("and/or", "well-known", "state-of-the-art", "1.2.3-beta.4", "UI/UX") is not mangled.
- Adds container CSS tuning table per surface type (prose / code blocks / diff viewers / narrow flex panels with `min-width: 0`).

## Changes

Files added (both at `sidebar_position: 5`):

- `src/content/docs/typography/text-control/long-url-and-path-wrapping.mdx` (EN, 531 lines)
- `src/content/docs-ja/typography/text-control/long-url-and-path-wrapping.mdx` (JA mirror, 531 lines)

Article sections: The Problem → Why the One-Liners Fall Short (comparison table) → The `<wbr>` Injection Strategy → Delimiter Set → The `isPathLike` Gate (Prose Guard) → Container CSS Tuning → Zero-Width Space (U+200B) — Text-Only Fallback → Common AI Mistakes → When to Use → References.

Five `<CssPreview>` demos (D1–D5):

- D1 — Side-by-side comparison of 4 rules in a ~240px column
- D2 — `<wbr>`-injected path/URL next to an uninjected version
- D3 — `isPathLike` gate illustration (prose vs. path)
- D4 — `U+200B` text-only demo
- D5 — Container CSS comparison (`overflow-wrap: break-word` vs. `anywhere`)

Required warnings present as prose (not only table-implied):

- Do NOT mix `word-break: break-all` with smart-break on the same element.
- `white-space: pre-wrap` on fenced code defeats `overflow-wrap: break-word`.

Review fix applied (codex-review, P2): corrected the `word-break: break-word` row — it is not a "legacy alias" for `overflow-wrap: break-word`; it is a non-standard Chrome value whose emergency breaking is as aggressive as `overflow-wrap: anywhere` (roughly `word-break: normal` plus `overflow-wrap: anywhere`). Same fix applied to the JA mirror.

## Test Plan

- [x] `pnpm check` (astro sync + tsc --noEmit) passes
- [x] `pnpm build` completes; both `/docs/typography/text-control/long-url-and-path-wrapping` and `/ja/docs/typography/text-control/long-url-and-path-wrapping` routes are in the build output
- [x] EN/JA parity verified: code blocks, all `<CssPreview>` `html=` / `css=` props, and imports are byte-identical
- [x] CI green on PR #45 (Type Check + Build / Link Check / Preview Deploy)
- [ ] Reviewer: spot-check D1's four rules produce visibly different wrapping in a ~240px container (requires preview deploy)

## Tracking

- Epic: #42
- Sub EN: #43
- Sub JA: #44

Delivered via `/x-wt-teams` with `-gcoc -co` Combined Reviewer Mode. Child branches merged locally into the base branch; topic branches deleted after merge.