### PR TITLE
feat(dev): port-rotation dev launcher (fix zfb next.36 `--host` arg-parse break)

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -4,6 +4,7 @@
 #
 # CI jobs:
 #   Type Check    — pnpm install; pnpm check
+#   Unit Tests    — pnpm install; pnpm test:unit (vitest run scripts/, no dist)
 #   Build Site    — full clone, pnpm install; CI=true zfb build
 #   HTML Validate — needs build-site; pnpm check:html
 #   Check Links   — needs build-site; check-links.js --strict-broken --strict-absolute
@@ -133,6 +134,34 @@ jobs:
 
       - name: Run type checking
         run: pnpm check
+
+  # ---------------------------------------------------------------------------
+  # Job 1a: Unit tests (vitest run scripts/ — pure unit tests, no dist needed)
+  # ---------------------------------------------------------------------------
+  # Covers the port-rotation helper (scripts/lib/find-free-port.mjs, incl. its
+  # WSL2 connect-timeout behavior) and check-links. Independent of the build.
+  unit-tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run unit tests
+        run: pnpm test:unit
 
   # ---------------------------------------------------------------------------
   # Job 2: Build site (full clone — needed for SSG meta dates)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ CSS best practices documentation site, built with zudo-doc (zfb framework, MDX, 
 Package manager: **pnpm** (Node.js >= 20).
 
 ```bash
-pnpm dev              # Dev server (kills port 4321, starts zfb dev)
+pnpm dev              # Dev server (port-rotation launcher: probes 3000, walks +1 to first free; DEV_PORT overrides)
 pnpm build            # Production build → dist/
 pnpm preview          # Preview built site
 pnpm check            # Type checking (zfb check)

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "setup:doc-skill": "bash scripts/setup-doc-skill.sh",
     "generate:css-wisdom": "node scripts/generate-css-wisdom.js",
     "test:e2e": "vitest run e2e/",
+    "test:unit": "vitest run scripts/",
     "deploy": "wrangler deploy"
   },
   "pnpm": {

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "type": "module",
   "packageManager": "pnpm@10.33.0",
   "scripts": {
-    "predev": "lsof -ti:4321 | xargs -r kill || true",
-    "dev": "zfb dev --host",
+    "dev": "node scripts/dev-launcher.mjs",
     "build": "zfb build",
     "preview": "zfb preview",
     "check": "zfb check",

--- a/scripts/__tests__/find-free-port.test.ts
+++ b/scripts/__tests__/find-free-port.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Unit tests for `find-free-port.mjs` — the port auto-selection helper behind
+ * the dev launcher.
+ *
+ * COPY-TEMPLATE: this test runs in a vitest-configured project. After copying,
+ * adjust the relative import at the bottom to wherever you placed the helper
+ * (helper at `scripts/lib/find-free-port.mjs`, test at `scripts/__tests__/`).
+ *
+ * Contract: `findFreePort(preferred)` returns `preferred` when it is free,
+ * walks +1 per occupied port, and throws when `maxTries` is exhausted.
+ *
+ * Determinism: `node:net` is stubbed so port-freeness is driven by an
+ * in-memory set instead of real OS sockets. Binding real ephemeral ports then
+ * asserting on the exact number flakes under local port contention when the
+ * just-freed port is stolen before the assertion. Stubbing removes the real
+ * binds entirely, so the walk/exclude/throw contract is exercised
+ * deterministically. (Real-socket probe behavior is covered in practice by
+ * running the dev server itself.)
+ *
+ * The SUT consumes `connect` through `node:net`'s CJS-interop default export,
+ * so the factory must override `connect` on BOTH the named export and
+ * `default` — overriding only the named export leaves the SUT reading the real
+ * socket. The fake `connect` is defined inside the (hoisted) factory; only the
+ * `vi.hoisted` `busy` set may be referenced from it.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Loopback families probed by the SUT's `isPortFree`, in `host:port` key form.
+const V4 = '127.0.0.1';
+const V6 = '::1';
+
+// Sets of `host:port` keys, controlled per-test. Hoisted so the (hoisted)
+// vi.mock factory closes over the same instances the tests mutate.
+//   busy      → connect succeeds (a real listener answers)
+//   timeouts  → connect hangs past the deadline (WSL2 closed-port behavior)
+const { busy, timeouts } = vi.hoisted(() => ({
+  busy: new Set<string>(),
+  timeouts: new Set<string>(),
+}));
+
+vi.mock('node:net', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  const { EventEmitter } = await import('node:events');
+
+  // Deterministic stand-in for a TCP connect probe: an occupied port accepts
+  // the connection (`connect`), a "hanging" port emits `timeout`, and any other
+  // port refuses (`error`).
+  const connect = ({ host, port }: { host: string; port: number }) => {
+    const socket = new EventEmitter() as EventEmitter & {
+      unref: () => void;
+      setTimeout: (ms: number) => void;
+      destroy: () => void;
+    };
+    socket.unref = () => {};
+    socket.setTimeout = () => {};
+    socket.destroy = () => {};
+    // Emit on a microtask so `canConnect` has attached its listeners first.
+    queueMicrotask(() => {
+      const key = `${host}:${port}`;
+      if (timeouts.has(key)) socket.emit('timeout');
+      else if (busy.has(key)) socket.emit('connect');
+      else socket.emit('error', new Error('ECONNREFUSED'));
+    });
+    return socket;
+  };
+
+  const actualDefault = (actual.default ?? {}) as Record<string, unknown>;
+  return { ...actual, connect, default: { ...actualDefault, connect } };
+});
+
+// @ts-expect-error - .mjs source has no TypeScript declarations and the project does not generate them; import shape is exercised at runtime.
+import { findFreePort, isPortFree } from '../lib/find-free-port.mjs';
+
+/** Mark a port occupied on the given loopback families (both by default). */
+function occupy(port: number, families: Array<'v4' | 'v6'> = ['v4', 'v6']): void {
+  for (const family of families) busy.add(`${family === 'v4' ? V4 : V6}:${port}`);
+}
+
+/** Mark a port as hanging (connect times out) on the given families. */
+function timeoutOn(port: number, families: Array<'v4' | 'v6'> = ['v4', 'v6']): void {
+  for (const family of families) timeouts.add(`${family === 'v4' ? V4 : V6}:${port}`);
+}
+
+describe('find-free-port', () => {
+  beforeEach(() => {
+    busy.clear();
+    timeouts.clear();
+  });
+
+  it('isPortFree returns false for an occupied port and true for a free one', async () => {
+    occupy(5000);
+
+    expect(await isPortFree(5000)).toBe(false);
+    expect(await isPortFree(6000)).toBe(true);
+  });
+
+  it('isPortFree treats a port busy on only one loopback family as occupied', async () => {
+    // The SUT ANDs both families (`!v4Busy && !v6Busy`) precisely because a
+    // macOS wildcard test-bind can look free on one family while in use — a
+    // single-family hit must still report "busy".
+    occupy(5000, ['v4']);
+
+    expect(await isPortFree(5000)).toBe(false);
+  });
+
+  it('returns the preferred port when it is free', async () => {
+    expect(await findFreePort(5000)).toBe(5000);
+  });
+
+  it('walks +1 when the preferred port is occupied', async () => {
+    occupy(5000);
+
+    expect(await findFreePort(5000)).toBe(5001);
+  });
+
+  it('walks past a contiguous run of occupied ports', async () => {
+    occupy(5000);
+    occupy(5001);
+    occupy(5002);
+
+    expect(await findFreePort(5000)).toBe(5003);
+  });
+
+  it('treats a connect timeout as free (WSL2: closed 127.0.0.1 hangs instead of refusing)', async () => {
+    // The exact WSL2 failure mode: IPv4 connect to a closed port hangs to the
+    // deadline while IPv6 refuses. A timeout must count as "not connected" =
+    // free, or every probe would report busy and resolution would never finish.
+    timeoutOn(5000, ['v4']); // v6 refuses (not in any set)
+
+    expect(await isPortFree(5000)).toBe(true);
+    expect(await findFreePort(5000)).toBe(5000);
+  });
+
+  it('still reports busy when a real listener answers on v4 even if v6 times out', async () => {
+    // Only an ACTUAL connection marks busy — a timeout on the other family must
+    // not flip a genuinely-occupied port to "free" (protects the shift-instead-
+    // of-kill behavior for an existing dev server).
+    occupy(5000, ['v4']);
+    timeoutOn(5000, ['v6']);
+
+    expect(await isPortFree(5000)).toBe(false);
+  });
+
+  it('skips excluded ports even when they are free', async () => {
+    // 5000 is free but promised to another process this run — the next
+    // candidate must be returned instead.
+    expect(await findFreePort(5000, { exclude: [5000] })).toBe(5001);
+  });
+
+  it('throws when no free port exists within maxTries', async () => {
+    occupy(5000);
+    occupy(5001);
+
+    await expect(findFreePort(5000, { maxTries: 2 })).rejects.toThrow(/No free port found/);
+  });
+});

--- a/scripts/dev-launcher.mjs
+++ b/scripts/dev-launcher.mjs
@@ -1,0 +1,134 @@
+/**
+ * Dev launcher — port auto-selection instead of killing port-holders.
+ *
+ * Probes the preferred port and walks forward (+1, +2, ...) to the first free
+ * one, then spawns the dev server on it. Replaces the common
+ * `predev: lsof -ti :PORT | xargs kill` flow, which can take down a process
+ * the user wanted alive (another app, a second checkout, a debugger).
+ *
+ * Override the preferred port via env (see PREFERRED_PORT below).
+ *
+ * Flags:
+ *   --strict-port   fail instead of shifting when the preferred port is busy.
+ *                   For automation that needs a deterministic URL — e.g. a
+ *                   Playwright `webServer.command` whose `url` must match the
+ *                   port the launcher actually binds.
+ *
+ * TEMPLATE: edit the marked block for your project. For a multi-process dev
+ * server (server + sidecar), see multi-process.md in the skill.
+ */
+
+import { spawn } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { findFreePort, isPortFree } from './lib/find-free-port.mjs';
+
+const scriptsDir = dirname(fileURLToPath(import.meta.url));
+
+// Make project bins (node_modules/.bin) resolvable even when this is invoked
+// as `node scripts/dev-launcher.mjs` directly (e.g. a Playwright webServer
+// command) — not just via the npm/pnpm-script PATH, which prepends .bin itself.
+const binDir = join(scriptsDir, '..', 'node_modules', '.bin');
+const childPath = `${binDir}:${process.env.PATH ?? ''}`;
+
+// ── EDIT FOR YOUR PROJECT ──────────────────────────────────────────────────
+const PREFERRED_PORT = Number(process.env.DEV_PORT) || 3000;
+// zfb's dev server takes `--port <n>`. `--host 0.0.0.0` exposes it on the LAN
+// (e.g. reachable from a Windows host under WSL2) — this preserves the original
+// bare-`zfb dev --host` intent under zfb next.36's value-required `--host`
+// (see Takazudo/zudo-front-builder#891 for the bare-flag ergonomics proposal).
+const buildCommand = (port) => ({
+  cmd: 'zfb',
+  args: ['dev', '--port', String(port), '--host', '0.0.0.0'],
+  env: {},
+});
+// ───────────────────────────────────────────────────────────────────────────
+
+const strictPort = process.argv.slice(2).includes('--strict-port');
+
+const COLORS = { yellow: '\x1b[33m', reset: '\x1b[0m' };
+
+async function resolvePort(preferred) {
+  if (strictPort) {
+    if (!(await isPortFree(preferred))) {
+      console.error(`[dev-launcher] --strict-port: port ${preferred} is busy`);
+      process.exit(1);
+    }
+    return preferred;
+  }
+  return findFreePort(preferred);
+}
+
+const port = await resolvePort(PREFERRED_PORT);
+const shifted =
+  port !== PREFERRED_PORT
+    ? ` ${COLORS.yellow}(${PREFERRED_PORT} was busy — shifted)${COLORS.reset}`
+    : '';
+
+console.log('');
+console.log('=== dev port ===');
+console.log(`  port: ${port}${shifted}`);
+console.log(`  → http://localhost:${port}/`);
+console.log('');
+
+const { cmd, args, env } = buildCommand(port);
+
+// detached: true puts the child in its own process group so shutdown can
+// signal the whole tree via process.kill(-pid). Many CLI bins are a shim →
+// node wrapper → spawned binary; signaling only the wrapper orphans the real
+// server, which keeps the port bound.
+//
+// Clean self-shutdown matters MORE here than under a kill-port flow, not less:
+// with no kill-port step, an orphaned dev server silently pushes every future
+// run +1. The SIGKILL escalation + exit sweep below guarantee we release our
+// own port on the way out.
+const child = spawn(cmd, args, {
+  stdio: 'inherit',
+  detached: true,
+  env: { ...process.env, ...env, PATH: childPath },
+});
+
+let shuttingDown = false;
+
+function killTree(signal) {
+  if (child.exitCode !== null) return;
+  try {
+    process.kill(-child.pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      // already gone
+    }
+  }
+}
+
+function shutdown(signal = 'SIGTERM') {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  killTree(signal);
+  const killTimer = setTimeout(() => killTree('SIGKILL'), 2000);
+  killTimer.unref();
+}
+
+// Last-resort sweep: if the event loop drains unexpectedly, take the child
+// with us (kill(2) is a sync syscall — safe in 'exit').
+process.on('exit', () => killTree('SIGKILL'));
+
+child.on('exit', (code) => {
+  if (!shuttingDown) {
+    process.exitCode = code ?? 1;
+    shutdown();
+  }
+});
+child.on('error', (err) => {
+  console.error(`[dev-launcher] failed to start ${cmd}: ${err.message}`);
+  process.exitCode = 1;
+  shutdown();
+});
+
+// The child is in its own process group (detached), so a terminal Ctrl-C
+// reaches only this launcher — forward it explicitly, or Ctrl-C won't stop the
+// server.
+process.on('SIGINT', () => shutdown('SIGINT'));
+process.on('SIGTERM', () => shutdown('SIGTERM'));

--- a/scripts/dev-launcher.mjs
+++ b/scripts/dev-launcher.mjs
@@ -37,6 +37,17 @@ const PREFERRED_PORT = Number(process.env.DEV_PORT) || 3000;
 // (e.g. reachable from a Windows host under WSL2) — this preserves the original
 // bare-`zfb dev --host` intent under zfb next.36's value-required `--host`
 // (see Takazudo/zudo-front-builder#891 for the bare-flag ergonomics proposal).
+//
+// KNOWN LIMITATION (best-effort probe): find-free-port probes the loopback
+// interfaces, but the server binds the IPv4 wildcard (0.0.0.0). If another
+// process is bound ONLY to a specific non-loopback address (e.g. a LAN IP) on
+// the chosen port, the probe sees it as free and zfb's wildcard bind then
+// fails with EADDRINUSE. That is uncommon for dev tooling and fails LOUDLY —
+// zfb prints the bind error and exits, and `child.on('exit')` below propagates
+// the non-zero code — so it surfaces clearly rather than corrupting state; set
+// DEV_PORT to step around it. A robust fix would need a wildcard test-bind,
+// which the connect-probe deliberately avoids (macOS reports such binds free
+// even when the port is held). Tracked for an upstream skill improvement.
 const buildCommand = (port) => ({
   cmd: 'zfb',
   args: ['dev', '--port', String(port), '--host', '0.0.0.0'],

--- a/scripts/lib/find-free-port.mjs
+++ b/scripts/lib/find-free-port.mjs
@@ -1,0 +1,98 @@
+/**
+ * Free-port resolution for a dev launcher (replaces a kill-port flow).
+ *
+ * Instead of force-killing whatever listens on the preferred dev port,
+ * the launcher probes the preferred port and walks forward (+1, +2, ...)
+ * to the first free one. See `dev-launcher.mjs` for the consumer.
+ *
+ * The probe CONNECTS to the loopback addresses instead of test-binding a
+ * listener: Node listeners set SO_REUSEADDR, and on macOS that lets a
+ * wildcard test-bind succeed even while another process holds
+ * 127.0.0.1:<port> — a listen()-probe reports "free" for ports that are
+ * very much in use (observed with a running dev server). A successful TCP
+ * connect on either loopback family means something is listening → busy;
+ * a connection that is refused — OR that times out with no answer — means
+ * free. (WSL2 quirk: a connect to a CLOSED 127.0.0.1:<port> is not promptly
+ * refused with an RST; it hangs until the deadline. So a timeout must count as
+ * "free", not "busy" — otherwise every IPv4 probe would report busy and port
+ * resolution would never succeed.) There is an inherent TOCTOU race between
+ * probe and the real server's bind — acceptable for dev tooling; the real
+ * server fails loudly if the port is stolen in between.
+ */
+
+import { connect } from 'node:net';
+
+// A loopback listener answers a connect in single-digit ms, so a short deadline
+// is plenty to catch a real server. Kept low because on WSL2 a closed IPv4 port
+// hangs until this deadline on EVERY free-port probe (see module doc-comment).
+const CONNECT_TIMEOUT_MS = 200;
+
+/**
+ * Try a TCP connect; resolves true if a connection is established
+ * (= something is listening there).
+ *
+ * @param {string} host
+ * @param {number} port
+ * @returns {Promise<boolean>}
+ */
+function canConnect(host, port) {
+  return new Promise((resolve) => {
+    const socket = connect({ host, port });
+    socket.unref();
+    socket.setTimeout(CONNECT_TIMEOUT_MS);
+    socket.once('connect', () => {
+      socket.destroy();
+      resolve(true);
+    });
+    // ECONNREFUSED / EADDRNOTAVAIL (no such loopback family) etc. → not listening.
+    socket.once('error', () => resolve(false));
+    // A timeout means nothing answered the connect within the deadline → treat
+    // as "no connection established" = free. Required on WSL2, where a connect
+    // to a CLOSED 127.0.0.1:<port> hangs instead of being refused; counting
+    // that as busy made every IPv4 probe report busy and broke resolution. A
+    // genuinely-running server fires `connect` (above) in single-digit ms, so
+    // only an actual connection marks a port busy — the "shift instead of kill
+    // an existing dev server" behavior is preserved.
+    socket.once('timeout', () => {
+      socket.destroy();
+      resolve(false);
+    });
+  });
+}
+
+/**
+ * Check whether a TCP port is free on both loopback families.
+ *
+ * @param {number} port
+ * @returns {Promise<boolean>}
+ */
+export async function isPortFree(port) {
+  const [v4Busy, v6Busy] = await Promise.all([
+    canConnect('127.0.0.1', port),
+    canConnect('::1', port),
+  ]);
+  return !v4Busy && !v6Busy;
+}
+
+/**
+ * Find the first free port starting at `preferred`, walking +1 each try.
+ *
+ * @param {number} preferred - the port to try first
+ * @param {{ maxTries?: number, exclude?: Iterable<number> }} [options]
+ *   `exclude` skips ports already promised to another process this run —
+ *   probe-then-spawn means a probed-free port is not actually bound yet, so
+ *   two sequential findFreePort calls could otherwise pick the same port.
+ * @returns {Promise<number>} the first free port
+ * @throws when no free port is found within `maxTries` attempts
+ */
+export async function findFreePort(preferred, { maxTries = 20, exclude = [] } = {}) {
+  const excluded = new Set(exclude);
+  for (let i = 0; i < maxTries; i++) {
+    const candidate = preferred + i;
+    if (excluded.has(candidate)) continue;
+    if (await isPortFree(candidate)) return candidate;
+  }
+  throw new Error(
+    `No free port found in range ${preferred}-${preferred + maxTries - 1} (${maxTries} tries)`,
+  );
+}

--- a/scripts/run-b4push.sh
+++ b/scripts/run-b4push.sh
@@ -7,10 +7,11 @@ set -euo pipefail
 #   1. Format check (mdx)  (mdx-formatter --check; config in .mdx-formatter.json)
 #   2. Pin parity check    (pure-Node, reads package.json only)
 #   3. Template drift check (needs node_modules — create-zudo-doc devDep)
-#   4. Type checking       (zfb check)
-#   5. Build               (zfb build)
-#   6. HTML validation     (html-validate dist/**/*.html)
-#   7. Link check          (check:links --strict-broken --strict-absolute)
+#   4. Unit tests          (vitest run scripts/ — pure, no dist needed)
+#   5. Type checking       (zfb check)
+#   6. Build               (zfb build)
+#   7. HTML validation     (html-validate dist/**/*.html)
+#   8. Link check          (check:links --strict-broken --strict-absolute)
 #
 # Env overrides for non-interactive use:
 #   B4PUSH_SKIP_HTML_VALIDATE=1  — skip HTML validation (step 6)
@@ -18,7 +19,7 @@ set -euo pipefail
 
 START_TIME=$(date +%s)
 FAILURES=()
-TOTAL_STEPS=7
+TOTAL_STEPS=8
 CURRENT_STEP=0
 
 step() {
@@ -67,7 +68,17 @@ else
   fail "Template drift check"
 fi
 
-# ── Step 4: Type checking ─────────────────────────────
+# ── Step 4: Unit tests ────────────────────────────────
+# Pure vitest unit tests under scripts/__tests__/ (no dist/ needed). Guards the
+# port-rotation helper (incl. its WSL2 connect-timeout behavior) and check-links.
+step "Unit tests (test:unit)"
+if (cd "$ROOT_DIR" && pnpm test:unit); then
+  pass "Unit tests passed"
+else
+  fail "Unit tests"
+fi
+
+# ── Step 5: Type checking ─────────────────────────────
 step "Type checking (zfb check)"
 if (cd "$ROOT_DIR" && pnpm check); then
   pass "Type checking passed"
@@ -75,7 +86,7 @@ else
   fail "Type checking"
 fi
 
-# ── Step 5: Build ─────────────────────────────────────
+# ── Step 6: Build ─────────────────────────────────────
 step "Build (zfb build)"
 if (cd "$ROOT_DIR" && pnpm build); then
   pass "Build passed"
@@ -83,7 +94,7 @@ else
   fail "Build"
 fi
 
-# ── Step 6: HTML validation ───────────────────────────
+# ── Step 7: HTML validation ───────────────────────────
 step "HTML validation (html-validate)"
 if [[ "${B4PUSH_SKIP_HTML_VALIDATE:-}" == "1" ]]; then
   skip "HTML validation (B4PUSH_SKIP_HTML_VALIDATE=1)"
@@ -95,7 +106,7 @@ else
   fi
 fi
 
-# ── Step 7: Link check ────────────────────────────────
+# ── Step 8: Link check ────────────────────────────────
 #
 # Strict on broken links + absolute MDX-source warnings.
 # Allowlist file at `.check-links-allowlist` carries known exceptions.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    include: ["e2e/**/*.test.ts"],
+    // e2e/ reads built dist/ HTML; scripts/__tests__/ are pure unit tests.
+    // The package scripts filter this set: `test:e2e` → `vitest run e2e/`,
+    // `test:unit` → `vitest run scripts/`.
+    include: ["e2e/**/*.test.ts", "scripts/**/*.test.ts"],
   },
 });


### PR DESCRIPTION
- parent PR
    - https://github.com/zudolab/zudo-css-wisdom/pull/98

---

## Summary

Replaces the broken `pnpm dev` and the old `predev` port-kill with a **port-rotation dev launcher**.

zfb **next.36** changed the dev CLI so `--host` requires an explicit value (it was a bare flag in next.35), so the existing `dev` script `zfb dev --host` errored at arg-parse (`a value is required for '--host <HOST>'`). Rather than just restore a one-off `--host 0.0.0.0`, this swaps the destructive `predev` port-kill (whose `4321` was a stale Astro-era leftover; zfb serves on `3000`) for a launcher that probes the preferred port and walks `+1` to the first free one, then runs `zfb dev --port <n> --host 0.0.0.0`. A second checkout/worktree, a debugger, or any held port no longer takes down a foreign process — and the launcher prints the chosen port.

## Changes

**Dev launcher**

- `scripts/lib/find-free-port.mjs` — connect-probe free-port finder (adapted from the `dev-port-rotation-serve` skill asset). **WSL2 fix:** a connect to a _closed_ `127.0.0.1:<port>` hangs instead of refusing, so a connect _timeout_ is treated as free, not busy (otherwise every IPv4 probe reports busy and resolution never succeeds). Only an actual `connect` marks a port busy, so detecting/shifting around an existing dev server still works.
- `scripts/dev-launcher.mjs` — resolves the port, then spawns `zfb dev` **detached** (own process group) with SIGTERM→SIGKILL tree teardown + SIGINT forwarding, so the port is **released on exit** (no orphan pushing future runs `+1`).
- `package.json` — `dev` → `node scripts/dev-launcher.mjs`; removed the `predev` port-kill. `DEV_PORT` overrides the preferred port.
- `CLAUDE.md` — updated the `pnpm dev` description.

**Tests + CI (codex review P3)**

- `scripts/__tests__/find-free-port.test.ts` — contract tests incl. the timeout→free path that regression-guards the WSL2 divergence.
- `vitest.config.ts` — broadened `include` to `scripts/**`; added `test:unit` (`vitest run scripts/`), a b4push step, and a dedicated **Unit Tests** CI job. (`test:e2e` stays scoped to `e2e/`.) This also revives the previously-dormant `check-links` unit test — 63 unit tests now run in CI.

## Known limitation (codex review P2 → #102)

The probe checks loopback while the server binds the IPv4 wildcard, so a non-loopback-only holder on the chosen port yields a loud `EADDRINUSE` (propagated as a non-zero exit) rather than a rotation. Documented in `dev-launcher.mjs`; tracked in #102 (a robust fix needs a wildcard test-bind the connect-probe deliberately avoids — best fixed upstream in the skill asset).

## Test Plan

- `pnpm test:unit` → 63 pass (incl. the 2 timeout-path cases for the WSL2 fix).
- End-to-end via `pnpm dev`: launcher resolves `:3000` → zfb serves HTTP 200 → `ss` shows `LISTEN 0.0.0.0:3000` → SIGTERM the launcher → port released within seconds, no stray procs.
- `CI=true pnpm b4push` → all 8 gates green (250 pages).

## Upstream

- Bare-`--host` ergonomics improvement filed at `Takazudo/zudo-front-builder#891` (proposes clap `num_args = 0..=1, default_missing_value = "0.0.0.0"`). The launcher passes the explicit `--host 0.0.0.0` workaround meanwhile.
