### PR TITLE
fix(islands): add missing "use client" to doc-history and image-enlarge

### DIFF
--- a/.template-drift-allowlist
+++ b/.template-drift-allowlist
@@ -56,8 +56,10 @@ tsconfig.json
 # ── Feature islands: enabled feature's real impl overrides the base no-op stub
 # These three files exist in BOTH base/ (no-op stub) and their feature/ dir
 # (real island). zcss has the features enabled, so the production file is the
-# real island — which DIFFs against the base stub in the base/ pass. The real
-# impl matches its feature template; the divergence is base-stub-vs-real only.
+# real island — which DIFFs against the base stub in the base/ pass.
+# doc-history.tsx / image-enlarge.tsx additionally prepend "use client" (the
+# 0.2.1 feature templates omit it, leaving the islands unregistered —
+# zudolab/zudo-doc#2047); drop that divergence when the templates ship it.
 src/components/desktop-sidebar-toggle.tsx
 src/components/doc-history.tsx
 src/components/image-enlarge.tsx

--- a/src/components/doc-history.tsx
+++ b/src/components/doc-history.tsx
@@ -1,3 +1,9 @@
+"use client";
+
+// Directive missing from the create-zudo-doc 0.2.1 feature template — without
+// it zfb's island scanner never registers the component and the DocHistory
+// panel ships dead (zudolab/zudo-doc#2047; local tracking zudo-css-wisdom#104).
+// Drop this divergence when the template ships the directive upstream.
 import { useState, useEffect, useCallback, useMemo, useRef } from "preact/compat";
 import type { Change } from "diff";
 import type { DocHistoryData, DocHistoryEntry } from "@/types/doc-history";

--- a/src/components/image-enlarge.tsx
+++ b/src/components/image-enlarge.tsx
@@ -1,3 +1,9 @@
+"use client";
+
+// Directive missing from the create-zudo-doc 0.2.1 feature template — without
+// it zfb's island scanner never registers the component and image-enlarge
+// zoom ships dead (zudolab/zudo-doc#2047; local tracking zudo-css-wisdom#104).
+// Drop this divergence when the template ships the directive upstream.
 import { useState, useEffect, useRef } from "preact/compat";
 import type { JSX } from "preact";
 


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-css-wisdom/issues/104 (partially addresses — DocHistory/ImageEnlarge half)
- parent PR
    - https://github.com/zudolab/zudo-css-wisdom/pull/98

---

## Summary

Auto-fix follow-up to #103. The create-zudo-doc 0.2.1 feature templates ship `doc-history.tsx` and `image-enlarge.tsx` without `"use client"`, so zfb's island scanner never registers them — the DocHistory panel and image-enlarge zoom have been shipping dead (pre-existing; surfaced by zfb next.38's island-marker warning; upstream: zudolab/zudo-doc#2047).

Adding the directive registers both: build island warnings drop from 6 to 4 and the islands entry bundle now contains their registry keys. The remaining four markers (Toc/MobileToc/Sidebar — package-side, blocked on Takazudo/zudo-front-builder#999; AiChatModal — no-op stub) stay tracked in #104.

## Changes

- `"use client"` + one-line provenance comment atop `src/components/doc-history.tsx` and `src/components/image-enlarge.tsx`
- `.template-drift-allowlist`: documents the intentional divergence until the templates ship the directive upstream

## Test Plan

- [x] `pnpm check` / `check:template-drift` green
- [x] `pnpm build`: DocHistory + ImageEnlarge island warnings gone; registry keys present in `dist/assets/islands-*.js`
- [x] Codex review: no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-css-wisdom/pr/105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783766562&installation_id=130359969&pr_number=105&repository=zudolab%2Fzudo-css-wisdom&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-css-wisdom%2Fpull%2F105&signature=9adcfddea32e13066d2c5f937a8b61c40fb289becc36599f9c6e330aea20fdce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->