### PR TITLE
ci: artifact-based dist handoff between PR-check jobs

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -191,11 +191,17 @@ jobs:
       - name: Build site
         run: CI=true pnpm exec zfb build
 
-      - name: Cache site build output
-        uses: actions/cache/save@v4
+      # Artifact (not actions/cache) for the within-run dist handoff: the cache
+      # service is eventually consistent and downstream restores ~19s after a
+      # successful save missed twice on 2026-06-11 (issue #107). Artifacts are
+      # run-scoped with no propagation lag; 1-day retention since nothing
+      # outside this run ever reads it.
+      - name: Upload site build output
+        uses: actions/upload-artifact@v4
         with:
+          name: dist
           path: dist/
-          key: dist-${{ github.run_id }}
+          retention-days: 1
 
   # ---------------------------------------------------------------------------
   # Job 3: HTML validate (block-in-inline guard)
@@ -221,12 +227,11 @@ jobs:
       - name: Install deps (no scripts)
         run: pnpm install --frozen-lockfile --ignore-scripts
 
-      - name: Restore dist cache
-        uses: actions/cache/restore@v4
+      - name: Download site build output
+        uses: actions/download-artifact@v4
         with:
+          name: dist
           path: dist/
-          key: dist-${{ github.run_id }}
-          fail-on-cache-miss: true
 
       - name: Run html-validate
         run: pnpm check:html
@@ -255,12 +260,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Restore dist cache
-        uses: actions/cache/restore@v4
+      - name: Download site build output
+        uses: actions/download-artifact@v4
         with:
+          name: dist
           path: dist/
-          key: dist-${{ github.run_id }}
-          fail-on-cache-miss: true
 
       - name: Check links (strict)
         run: node scripts/check-links.js --strict-broken --strict-absolute --allowlist=.check-links-allowlist
@@ -289,12 +293,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Restore dist cache
-        uses: actions/cache/restore@v4
+      - name: Download site build output
+        uses: actions/download-artifact@v4
         with:
+          name: dist
           path: dist/
-          key: dist-${{ github.run_id }}
-          fail-on-cache-miss: true
 
       - name: Run E2E tests
         run: pnpm test:e2e
@@ -312,12 +315,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
-      - name: Restore site build cache
-        uses: actions/cache/restore@v4
+      - name: Download site build output
+        uses: actions/download-artifact@v4
         with:
+          name: dist
           path: dist/
-          key: dist-${{ github.run_id }}
-          fail-on-cache-miss: true
 
       # Guard: assert the built HTML has root-relative asset URLs.
       # base="/" → href="/assets/..." and src="/assets/...".


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-css-wisdom/issues/107
- parent PR
    - https://github.com/zudolab/zudo-css-wisdom/pull/98

---

## Summary

Replaces the `actions/cache` run-scoped dist handoff (`dist-${{ github.run_id }}`, `fail-on-cache-miss: true`) with `actions/upload-artifact` / `actions/download-artifact`. The cache service is eventually consistent and bit us twice today — downstream restores ~19 seconds after a successful save missed the entry, failing HTML Validate / Check Links / E2E / Preview Deploy until a manual `gh run rerun --failed` (issue #107).

## Changes

- **Build Site**: `actions/cache/save` → `actions/upload-artifact` (`name: dist`, `retention-days: 1` — nothing outside the run reads it)
- **HTML Validate / Check Links / E2E Tests / Preview Deploy**: `actions/cache/restore` → `actions/download-artifact` (missing artifact still fails the job, preserving the `fail-on-cache-miss` guarantee)
- Side benefit: stops the per-run 4.9MB never-reused `dist-<run_id>` cache blobs accumulating against the 10GB cache quota

`dist/` verified to contain no hidden files or symlinks (upload-artifact v4 excludes hidden files by default and dereferences symlinks).

## Test Plan

- This PR's own CI run exercises the new handoff end-to-end — all four downstream jobs consume the artifact

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-css-wisdom/pr/108"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783779300&installation_id=130359969&pr_number=108&repository=zudolab%2Fzudo-css-wisdom&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-css-wisdom%2Fpull%2F108&signature=faa933e9e39fdca8af94c5467fc93b14e1800a525daca6727e42dcffdfdc89e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->