### PR TITLE
Add OGP image + Twitter card meta tags

### DIFF
--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -47,9 +47,9 @@ export const settings = {
   metaTags: {
     description: true,
     keywords: false,
-    ogImage: false,
+    ogImage: "/img/ogp.png",
     ogSiteName: true,
-    twitterCard: false,
+    twitterCard: "summary_large_image",
     twitterCreator: "@Takazudo",
   } satisfies MetaTagsConfig as MetaTagsConfig,
   docsDir: "src/content/docs",


### PR DESCRIPTION
## Summary
The production site emitted `og:title`, `og:type`, and `og:site_name` but **no `og:image`**, so social/link previews showed no image. The OGP asset already exists at `public/img/ogp.png` (the shared family image — byte-identical to `zudo-test-wisdom` and the old `takazudomodular.com/pj/zcss` version); only the config switch was off.

## Changes
- `src/config/settings.ts` → `metaTags`:
  - `ogImage: false` → `"/img/ogp.png"` (emits `og:image` + auto `og:image:width/height/alt` + `twitter:image`)
  - `twitterCard: false` → `"summary_large_image"` (large card for the 1200×630 banner)
- `ogSiteName: true` and `twitterCreator: "@Takazudo"` were already set — now emitted alongside.

## Test Plan
- `pnpm build` and confirm the built `<head>` emits `og:image`, `og:image:width/height/alt`, `twitter:card=summary_large_image`, `twitter:image`.