### PR TITLE
chore: add setup:doc-skill-silent variant for family uniformity

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "gen:z-index": "node scripts/gen-z-index.mjs",
     "check:z-index": "node scripts/gen-z-index.mjs --check",
     "generate:css-wisdom": "node scripts/generate-css-wisdom.js",
-    "setup:doc-skill": "node scripts/generate-css-wisdom.js && bash scripts/setup-doc-skill.sh"
+    "setup:doc-skill": "node scripts/generate-css-wisdom.js && bash scripts/setup-doc-skill.sh",
+    "setup:doc-skill-silent": "node scripts/generate-css-wisdom.js && bash scripts/setup-doc-skill.sh --silent"
   },
   "dependencies": {
     "@takazudo/zfb": "0.1.0-next.51",

--- a/scripts/setup-doc-skill.sh
+++ b/scripts/setup-doc-skill.sh
@@ -1,6 +1,21 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Accept --silent (alias -y) for uniformity with the rest of the *-wisdom family,
+# where setup-doc-skill.sh removes an interactive prompt under this flag. This script
+# is already non-interactive (skill name is hardcoded below; no prompt), so the flag
+# is a no-op here — but it must be parsed so the shared `setup:doc-skill-silent` flow
+# can call it without set -euo pipefail choking on an unknown argument.
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --silent|-y) shift ;;
+    *)
+      echo "Error: unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
 # ── setup-doc-skill.sh ─────────────────────────────────
 # Wires the css-wisdom doc-lookup skill: creates symlinks
 # for docs/ and docs-ja/ inside the skill directory, then


### PR DESCRIPTION
## Summary
Bring this repo's `setup:doc-skill` flow in line with the unified `*-wisdom` family convention by adding a `--silent` variant. This repo's `scripts/setup-doc-skill.sh` is already non-interactive (skill name hardcoded to `css-wisdom`, no `read`/prompt), so there is no prompt to remove — the change is purely for uniformity so the cross-repo automated flow can call `pnpm setup:doc-skill-silent` in every repo.

## Changes
- `scripts/setup-doc-skill.sh`: parse a `--silent` flag (alias `-y`) via a small arg-parsing loop near the top. The script has no prompt, so the flag is a behavioral no-op — it is parsed and accepted so `set -euo pipefail` does not choke on the unknown argument; any other unknown arg is rejected with exit 1. `set -euo pipefail` and all existing behavior are unchanged.
- `package.json`: add `setup:doc-skill-silent` right after `setup:doc-skill`, mirroring it with `--silent` appended (`node scripts/generate-css-wisdom.js && bash scripts/setup-doc-skill.sh --silent`).

## Test Plan
- `pnpm setup:doc-skill-silent` runs end-to-end non-interactively (generate step → silent symlink bake), exit 0, same output/result as `pnpm setup:doc-skill`.
- `bash scripts/setup-doc-skill.sh --bogus` rejects the unknown arg with exit 1.
- `bash -n` syntax check and `JSON.parse(package.json)` both pass.