### PR TITLE
ci: switch intra-run build-output hand-off from cache to artifacts

### DIFF
--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Upload site build output
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: dist-${{ github.run_id }}-${{ github.run_attempt }}
+          name: dist-${{ github.run_id }}
           path: dist/
           retention-days: 1
           if-no-files-found: error
@@ -107,7 +107,7 @@ jobs:
       - name: Download dist (built by build-site)
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          name: dist-${{ github.run_id }}-${{ github.run_attempt }}
+          name: dist-${{ github.run_id }}
           path: dist/
 
       - name: Run html-validate
@@ -152,7 +152,7 @@ jobs:
       - name: Upload doc history output
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: doc-history-${{ github.run_id }}-${{ github.run_attempt }}
+          name: doc-history-${{ github.run_id }}
           path: doc-history-out/
           retention-days: 1
           if-no-files-found: error
@@ -174,13 +174,13 @@ jobs:
       - name: Download site build output
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          name: dist-${{ github.run_id }}-${{ github.run_attempt }}
+          name: dist-${{ github.run_id }}
           path: dist/
 
       - name: Download doc history output
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          name: doc-history-${{ github.run_id }}-${{ github.run_attempt }}
+          name: doc-history-${{ github.run_id }}
           path: doc-history-out/
 
       - name: Prepare deploy directory

--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Upload site build output
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: dist-${{ github.run_id }}
+          name: dist-${{ github.run_id }}-${{ github.run_attempt }}
           path: dist/
           retention-days: 1
           if-no-files-found: error
@@ -106,7 +106,7 @@ jobs:
       - name: Download dist (built by build-site)
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          name: dist-${{ github.run_id }}
+          name: dist-${{ github.run_id }}-${{ github.run_attempt }}
           path: dist/
 
       - name: Run html-validate
@@ -151,7 +151,7 @@ jobs:
       - name: Upload doc history output
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: doc-history-${{ github.run_id }}
+          name: doc-history-${{ github.run_id }}-${{ github.run_attempt }}
           path: doc-history-out/
           retention-days: 1
           if-no-files-found: error
@@ -172,13 +172,13 @@ jobs:
       - name: Download site build output
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          name: dist-${{ github.run_id }}
+          name: dist-${{ github.run_id }}-${{ github.run_attempt }}
           path: dist/
 
       - name: Download doc history output
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          name: doc-history-${{ github.run_id }}
+          name: doc-history-${{ github.run_id }}-${{ github.run_attempt }}
           path: doc-history-out/
 
       - name: Prepare deploy directory

--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -7,9 +7,10 @@
 #   4. Merges both build outputs and deploys to Cloudflare Workers
 #   5. Sends IFTTT notification with deploy status
 #
-# Inter-job data sharing uses actions/cache (not upload-artifact) to avoid
-# Actions storage accumulation. Cache keys are scoped to github.run_id so
-# each run gets a fresh, unique cache that won't be reused by other runs.
+# Inter-job data sharing uses upload-artifact/download-artifact with
+# retention-days: 1, scoped to github.run_id. Artifacts (not cache) are used
+# because cache saves are best-effort and can silently fail, leaving consumers
+# to hard-fail on a missing cache; short retention keeps Actions storage clean.
 #
 # Concurrency: only one production deploy runs at a time.
 # We do NOT cancel in-progress runs -- the earlier deploy should finish.
@@ -67,11 +68,13 @@ jobs:
       - name: Build site
         run: pnpm build
 
-      - name: Cache site build output
-        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      - name: Upload site build output
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
+          name: dist-${{ github.run_id }}
           path: dist/
-          key: dist-${{ github.run_id }}
+          retention-days: 1
+          if-no-files-found: error
 
   # ---------------------------------------------------------------------------
   # Job: HTML validate
@@ -100,12 +103,11 @@ jobs:
       - name: Install deps (no scripts)
         run: pnpm install --frozen-lockfile --ignore-scripts
 
-      - name: Restore dist cache (built by build-site)
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      - name: Download dist (built by build-site)
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
+          name: dist-${{ github.run_id }}
           path: dist/
-          key: dist-${{ github.run_id }}
-          fail-on-cache-miss: true
 
       - name: Run html-validate
         run: pnpm check:html
@@ -146,11 +148,13 @@ jobs:
             --locale ja:src/content/docs-ja \
             --out-dir doc-history-out
 
-      - name: Cache doc history output
-        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      - name: Upload doc history output
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
+          name: doc-history-${{ github.run_id }}
           path: doc-history-out/
-          key: doc-history-${{ github.run_id }}
+          retention-days: 1
+          if-no-files-found: error
 
   # ---------------------------------------------------------------------------
   # Job 3: Deploy to Cloudflare Workers (production)
@@ -165,19 +169,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
-      - name: Restore site build cache
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      - name: Download site build output
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
+          name: dist-${{ github.run_id }}
           path: dist/
-          key: dist-${{ github.run_id }}
-          fail-on-cache-miss: true
 
-      - name: Restore doc history cache
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      - name: Download doc history output
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
+          name: doc-history-${{ github.run_id }}
           path: doc-history-out/
-          key: doc-history-${{ github.run_id }}
-          fail-on-cache-miss: true
 
       - name: Prepare deploy directory
         run: |

--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -75,6 +75,7 @@ jobs:
           path: dist/
           retention-days: 1
           if-no-files-found: error
+          overwrite: true
 
   # ---------------------------------------------------------------------------
   # Job: HTML validate
@@ -155,6 +156,7 @@ jobs:
           path: doc-history-out/
           retention-days: 1
           if-no-files-found: error
+          overwrite: true
 
   # ---------------------------------------------------------------------------
   # Job 3: Deploy to Cloudflare Workers (production)

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -186,6 +186,7 @@ jobs:
           path: dist/
           retention-days: 1
           if-no-files-found: error
+          overwrite: true
 
   # ---------------------------------------------------------------------------
   # Job: HTML validate
@@ -265,6 +266,7 @@ jobs:
           path: doc-history-out/
           retention-days: 1
           if-no-files-found: error
+          overwrite: true
 
   # ---------------------------------------------------------------------------
   # Job 4: Deploy preview and comment on PR

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -182,7 +182,7 @@ jobs:
       - name: Upload site build output
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: dist-${{ github.run_id }}
+          name: dist-${{ github.run_id }}-${{ github.run_attempt }}
           path: dist/
           retention-days: 1
           if-no-files-found: error
@@ -216,7 +216,7 @@ jobs:
       - name: Download dist (built by build-site)
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          name: dist-${{ github.run_id }}
+          name: dist-${{ github.run_id }}-${{ github.run_attempt }}
           path: dist/
 
       - name: Run html-validate
@@ -261,7 +261,7 @@ jobs:
       - name: Upload doc history output
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: doc-history-${{ github.run_id }}
+          name: doc-history-${{ github.run_id }}-${{ github.run_attempt }}
           path: doc-history-out/
           retention-days: 1
           if-no-files-found: error
@@ -282,13 +282,13 @@ jobs:
       - name: Download site build output
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          name: dist-${{ github.run_id }}
+          name: dist-${{ github.run_id }}-${{ github.run_attempt }}
           path: dist/
 
       - name: Download doc history output
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          name: doc-history-${{ github.run_id }}
+          name: doc-history-${{ github.run_id }}-${{ github.run_attempt }}
           path: doc-history-out/
 
       - name: Prepare dist for deployment

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -179,11 +179,13 @@ jobs:
       - name: Check links
         run: pnpm check:links
 
-      - name: Cache site build output
-        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      - name: Upload site build output
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
+          name: dist-${{ github.run_id }}
           path: dist/
-          key: dist-${{ github.run_id }}
+          retention-days: 1
+          if-no-files-found: error
 
   # ---------------------------------------------------------------------------
   # Job: HTML validate
@@ -211,12 +213,11 @@ jobs:
       - name: Install deps (no scripts)
         run: pnpm install --frozen-lockfile --ignore-scripts
 
-      - name: Restore dist cache (built by build-site)
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      - name: Download dist (built by build-site)
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
+          name: dist-${{ github.run_id }}
           path: dist/
-          key: dist-${{ github.run_id }}
-          fail-on-cache-miss: true
 
       - name: Run html-validate
         run: pnpm check:html
@@ -257,11 +258,13 @@ jobs:
             --locale ja:src/content/docs-ja \
             --out-dir doc-history-out
 
-      - name: Cache doc history output
-        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      - name: Upload doc history output
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
+          name: doc-history-${{ github.run_id }}
           path: doc-history-out/
-          key: doc-history-${{ github.run_id }}
+          retention-days: 1
+          if-no-files-found: error
 
   # ---------------------------------------------------------------------------
   # Job 4: Deploy preview and comment on PR
@@ -276,19 +279,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
-      - name: Restore site build cache
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      - name: Download site build output
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
+          name: dist-${{ github.run_id }}
           path: dist/
-          key: dist-${{ github.run_id }}
-          fail-on-cache-miss: true
 
-      - name: Restore doc history cache
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      - name: Download doc history output
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
+          name: doc-history-${{ github.run_id }}
           path: doc-history-out/
-          key: doc-history-${{ github.run_id }}
-          fail-on-cache-miss: true
 
       - name: Prepare dist for deployment
         run: |

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -182,7 +182,7 @@ jobs:
       - name: Upload site build output
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: dist-${{ github.run_id }}-${{ github.run_attempt }}
+          name: dist-${{ github.run_id }}
           path: dist/
           retention-days: 1
           if-no-files-found: error
@@ -217,7 +217,7 @@ jobs:
       - name: Download dist (built by build-site)
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          name: dist-${{ github.run_id }}-${{ github.run_attempt }}
+          name: dist-${{ github.run_id }}
           path: dist/
 
       - name: Run html-validate
@@ -262,7 +262,7 @@ jobs:
       - name: Upload doc history output
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: doc-history-${{ github.run_id }}-${{ github.run_attempt }}
+          name: doc-history-${{ github.run_id }}
           path: doc-history-out/
           retention-days: 1
           if-no-files-found: error
@@ -284,13 +284,13 @@ jobs:
       - name: Download site build output
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          name: dist-${{ github.run_id }}-${{ github.run_attempt }}
+          name: dist-${{ github.run_id }}
           path: dist/
 
       - name: Download doc history output
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          name: doc-history-${{ github.run_id }}-${{ github.run_attempt }}
+          name: doc-history-${{ github.run_id }}
           path: doc-history-out/
 
       - name: Prepare dist for deployment


### PR DESCRIPTION
## Summary

Both `pr-checks.yml` and `main-deploy.yml` pass build outputs (`dist/`, `doc-history-out/`) between jobs in the same run via the Actions **cache** backend — `actions/cache/save` producers keyed by `dist-${{ github.run_id }}` / `doc-history-${{ github.run_id }}`, and `actions/cache/restore` consumers with `fail-on-cache-miss: true`. Cache saves are best-effort/non-fatal, so when the cache backend rejects a save the producing job still goes green but every consumer hard-fails on `fail-on-cache-miss`. This is actively breaking this repo's deploys.

This PR switches the intra-run hand-off to **artifacts** (`actions/upload-artifact@v4` / `actions/download-artifact@v4`), which don't touch the cache backend. `retention-days: 1` preserves the original intent of not accumulating Actions storage.

## Changes
- (in progress)

## Test Plan
- This PR's own pr-checks run exercises the new `pr-checks.yml` — html-validate + Preview Deploy must now pass.
- Post-merge Production Deploy on `main` exercises `main-deploy.yml`.