### PR TITLE
fix(css): load Noto Sans JP @import above tailwindcss so browsers honor it (follow-up to #139)

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9,17 +9,23 @@
  * the lowest layer is observably inert for every other author rule (which stay
  * unlayered and continue to outrank it). */
 @layer zd-preflight, zd-flow;
-@import "tailwindcss/preflight" layer(zd-preflight);
-@import "tailwindcss/utilities";
 
 /* Noto Sans JP — body webfont for Japanese (and Latin) content, applied via
- * --font-noto / --font-sans below. Loaded here in global.css rather than a
- * <head> <link> because zudo-doc 2.0.0 collapsed the host head into the
- * package-owned chrome (no custom-head hook);  keeps the font working
- * uniformly across the homepage and every doc page. (was: async media=print
- * <link> in the former pages/lib/_head-with-defaults.tsx, removed in the 2.0.0
- * Collapse Wiring Shells migration.) */
+ * --font-noto / --font-sans below. Loaded as a CSS @import (not a <head> <link>)
+ * because zudo-doc 2.0.0 collapsed the host head into the package-owned chrome
+ * (no custom-head hook), so it must apply uniformly to the homepage and every
+ * doc page. (was: async media=print <link> in the former
+ * pages/lib/_head-with-defaults.tsx, removed in the 2.0.0 Collapse Wiring Shells
+ * migration.)
+ * MUST stay ABOVE the `@import "tailwindcss/..."` lines: Tailwind v4 inlines
+ * those local imports into real style rules in place, and the CSS spec only
+ * honors an @import that precedes all style rules — placed below them the
+ * browser silently drops this remote @import and the webfont never loads, while
+ * every build/lint gate still passes (regression caught in the 2.0.0 pilot). */
 @import url("https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@300;400;500;700&display=swap");
+
+@import "tailwindcss/preflight" layer(zd-preflight);
+@import "tailwindcss/utilities";
 
 /* ========================================
  * @takazudo/zudo-doc package safelist


### PR DESCRIPTION
## Follow-up fix to the zudo-doc 2.0.0 migration (#139)

The 2.0.0 "Collapse Wiring Shells" migration (#139, #138) relocated the **Noto Sans JP** webfont from the removed `pages/lib/_head-with-defaults.tsx` `<link>` into a CSS `@import` in `src/styles/global.css`. That `@import` was placed **below** the `@import "tailwindcss/..."` lines.

Tailwind v4 inlines those local imports into real style rules **in place**, so in the bundled `dist/assets/*.css` the remote Google-Fonts `@import` ended up **after** ~42 KB of style rules. Per the CSS spec, an `@import` that follows any style rule is invalid and **silently dropped by all browsers** — so the Japanese webfont stopped loading on the deployed site. Every build/lint/drift gate stayed green, which is why it shipped.

### Fix
Move the font `@import` **above** the `@import "tailwindcss/..."` lines so it precedes all style rules.

### Verification
- Rebuilt: the `@import` now sits at the top of `dist/assets/styles-*.css` (byte offset 115, nothing disallowed before it) → honored by browsers.
- `pnpm check:pin-parity`, `pnpm check:template-drift`, `pnpm check`, `pnpm build`, and full `scripts/run-b4push.sh` (all 8 steps) pass.

This bug was caught during the wisdom-fleet pilot deep-verification (positional dist-CSS check); the inline comment now documents the ordering constraint so it can't regress.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
