### PR TITLE
Widen the home page layout to fill the viewport (match zudo-doc showcase)

### DIFF
--- a/pages/[locale]/index.tsx
+++ b/pages/[locale]/index.tsx
@@ -1,0 +1,60 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+// Custom locale-home route overriding the plugin-injected `/[locale]` route
+// (@takazudo/zudo-doc/routes/locale-index, injected in the package's routes
+// plugin). Same reason as pages/index.tsx: the package route renders
+// HomePageView WITHOUT `wide` and zudo-doc 4.2.1 has no config toggle, so
+// without this override the JA home (/ja) stays narrow (3 cols) while the EN
+// home is wide — breaking EN/JA parity. `wide` widens the content band from
+// `max-width: 80rem` to `clamp(50rem, 92.5vw, 120rem)`.
+// Upstream request: https://github.com/zudolab/zudo-doc/issues/2959
+// Host pages override plugin-injected routes — precedent in this repo:
+// pages/[locale]/docs/[[...slug]].tsx overrides /[locale]/docs/[[...slug]].
+// Self-contained reconstruction (no pages/lib), mirroring pages/docs/[[...slug]].tsx.
+
+import type { JSX } from "preact";
+import { routeContext } from "virtual:zudo-doc-route-context";
+import {
+  createRouteContext,
+  type RouteContextPayload,
+} from "@takazudo/zudo-doc/route-context";
+import { createChrome } from "@takazudo/zudo-doc/chrome";
+import { DocHistory } from "@takazudo/zudo-doc/doc-history";
+import { defineChromeBindings } from "@takazudo/zudo-doc/chrome-bindings";
+import { chromeBindings } from "virtual:zudo-doc-chrome-bindings";
+import { prepareHomeData } from "@takazudo/zudo-doc/home-page";
+
+const ctx = routeContext as unknown as RouteContextPayload;
+const routeCtx = createRouteContext(ctx);
+const { HomePageView } = createChrome(routeCtx, {
+  ...chromeBindings,
+  ...defineChromeBindings({ DocHistory }),
+});
+
+export const frontmatter = { title: "Home" };
+
+export function paths(): Array<{
+  params: { locale: string };
+  props: { locale: string };
+}> {
+  return Object.keys(routeCtx.settings.locales).map((locale) => ({
+    params: { locale },
+    props: { locale },
+  }));
+}
+
+type PageArgs = { params: { locale: string } } & Record<string, unknown>;
+
+export default function LocaleIndexPage({ params }: PageArgs): JSX.Element {
+  const locale = params.locale;
+  const { tree, categoryOrder, tagCount } = prepareHomeData(routeCtx, locale);
+  return (
+    <HomePageView
+      locale={locale}
+      tree={tree}
+      categoryOrder={categoryOrder}
+      tagCount={tagCount}
+      wide
+    />
+  );
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,48 @@
-// Locked manifest (epic zudolab/zudo-doc#2651, Decision 4 on #2653): the home
-// route is a 1-line re-export of the package-owned STATIC index route.
-// Verified by the #2652 spike (Q2) to build, dev-render, and hydrate — a
-// dynamic route (see pages/docs/[[...slug]].tsx) cannot use this form because
-// `paths()` static-AST-extraction requires source, not compiled `dist/` JS.
-export { default } from "@takazudo/zudo-doc/routes/index";
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+// Custom home route — deliberately NOT the scaffold-default locked 1-line
+// re-export `export { default } from "@takazudo/zudo-doc/routes/index"`. That
+// package route renders HomePageView WITHOUT `wide`, and zudo-doc 4.2.1 exposes
+// no config toggle for the wide home grid, so the only way to match the
+// zudo-doc showcase is to reconstruct the route here and pass `wide`. `wide`
+// widens the content band from `max-width: 80rem` to `clamp(50rem, 92.5vw,
+// 120rem)`, letting the category grid fill the viewport (~4 cols) instead of 3.
+// Upstream request to add a config toggle so this host reconstruction is no
+// longer needed: https://github.com/zudolab/zudo-doc/issues/2959
+// Reconstruction mirrors the sanctioned self-contained pattern in
+// pages/docs/[[...slug]].tsx (same package entrypoints, no pages/lib).
+
+import type { JSX } from "preact";
+import { routeContext } from "virtual:zudo-doc-route-context";
+import {
+  createRouteContext,
+  type RouteContextPayload,
+} from "@takazudo/zudo-doc/route-context";
+import { createChrome } from "@takazudo/zudo-doc/chrome";
+import { DocHistory } from "@takazudo/zudo-doc/doc-history";
+import { defineChromeBindings } from "@takazudo/zudo-doc/chrome-bindings";
+import { chromeBindings } from "virtual:zudo-doc-chrome-bindings";
+import { prepareHomeData } from "@takazudo/zudo-doc/home-page";
+
+const ctx = routeContext as unknown as RouteContextPayload;
+const routeCtx = createRouteContext(ctx);
+const { HomePageView } = createChrome(routeCtx, {
+  ...chromeBindings,
+  ...defineChromeBindings({ DocHistory }),
+});
+
+export const frontmatter = { title: "Home" };
+
+export default function IndexPage(): JSX.Element {
+  const locale = routeCtx.defaultLocale;
+  const { tree, categoryOrder, tagCount } = prepareHomeData(routeCtx, locale);
+  return (
+    <HomePageView
+      locale={locale}
+      tree={tree}
+      categoryOrder={categoryOrder}
+      tagCount={tagCount}
+      wide
+    />
+  );
+}


### PR DESCRIPTION
## Summary
The home page category grid rendered only **3 narrow columns**, unlike the official zudo-doc showcase (**4+ columns**). Root cause: our home routes rendered `HomePageView` without the `wide` flag, so the content band got `data-zd-nosidebar` (`max-width: 80rem`) instead of `data-zd-wide` (`max-width: clamp(50rem, 92.5vw, 120rem)`). The home grid is `repeat(auto-fill, minmax(min(18rem,100%), 1fr))`, so column count follows the band width. This PR opts both the EN (`/`) and JA (`/ja`) home into the wide layout.

- EN home `pages/index.tsx` was the scaffold-default **locked 1-line re-export** of the package route (renders `wide=false`).
- JA home `/ja` was **auto-injected** from the package's `routes/locale-index` (also `wide=false`).

Neither could opt into `wide` because zudo-doc 4.2.1 exposes no config toggle. Upstream enhancement filed: https://github.com/zudolab/zudo-doc/issues/2959

## Changes
- **`pages/index.tsx`** — replaced the locked 1-line re-export with a self-contained reconstruction that renders `HomePageView` with `wide`. Uses the same sanctioned entrypoints already used by `pages/docs/[[...slug]].tsx` (`virtual:zudo-doc-route-context` → `createRouteContext` → `createChrome` → `HomePageView`; `prepareHomeData` from `@takazudo/zudo-doc/home-page`).
- **`pages/[locale]/index.tsx`** (new) — host override of the plugin-injected `/[locale]` route, mirroring the package `routes/locale-index` (`paths()` over configured locales) but passing `wide`. Precedent: the repo already overrides `/[locale]/docs/[[...slug]]`.

## Test Plan
- `pnpm check` — typecheck clean.
- `pnpm build` — 258 pages built; `dist/index.html` and `dist/ja/index.html` content-band element now carries the `data-zd-wide` attribute (was `data-zd-nosidebar` only).
- Headless browser @1700px (EN `/` and JA `/ja`): computed `grid-template-columns` = **4 columns** (359px each), content band `max-width` = 1572.5px (= 92.5vw). Screenshot confirms 4-column grid matching https://zudo-doc.takazudomodular.com/.
- Codex review: clean, no findings — reconstruction faithfully mirrors the package routes, no behavioral regression.

## Screenshot Requirement Contract
Expected:
- Home category grid fills most of the viewport (~4 columns at ~1700px), matching the zudo-doc showcase ✅
- Content band element carries `data-zd-wide` in built `dist/index.html` and `dist/ja/index.html` ✅

Forbidden:
- Home content band remains capped at `max-width: 80rem` (`data-zd-nosidebar` only) → 3 columns — resolved ✅
- JA home still narrow while EN is wide — resolved (both wide) ✅

Viewport:
- ~1700px desktop width

## Notes
- Upstream enhancement: https://github.com/zudolab/zudo-doc/issues/2959 (request a config toggle so this host reconstruction is no longer needed)