### PR TITLE
fix(home): restore the site's own home-hero logo (zudo-doc defaults to a generated one)

### DIFF
--- a/zfb.config.ts
+++ b/zfb.config.ts
@@ -26,6 +26,12 @@ export default defineConfig(
     locales: {
       ja: { label: "JA", dir: "src/content/docs-ja" },
     },
+    // Home-hero brand mark. MUST be set explicitly: zudo-doc's default is
+    // `"auto"`, a generated SVG seeded by `siteName` that silently replaces
+    // this site's own asset (the W banner settled in 84d2f19). Rendered as a
+    // theme-adaptive CSS mask in `bg-fg`, which is why the source SVG is a
+    // flat `fill:#fff` silhouette.
+    logo: "/img/logo.svg",
     // Wide home grid on `/` and every locale home. Replaces the former
     // hand-reconstructed pages/index.tsx + pages/[locale]/index.tsx, which
     // existed only because zudo-doc 4.2.1 had no toggle for the wide band


### PR DESCRIPTION
## Summary

zudo-doc's `logo` setting defaults to `"auto"` — a generated deterministic SVG seeded by `siteName`. This repo never set it, so `HomePageView` had silently swapped this site's own W-banner (`public/img/logo.svg`, settled in 84d2f19) for that placeholder.

One config line restores it. The asset itself is untouched, and so are `public/favicon.svg` and the rest of the allowlisted favicon set.

## Changes

- `zfb.config.ts` — added `logo: "/img/logo.svg"` plus a comment recording why it must be set explicitly (the upstream default silently replaces the host's brand mark; that is not recoverable from the code).

Diff is 6 added lines in 1 file. Nothing else touched.

## Why a path string is a faithful restoration, not a redesign

Per `dist/home-page/index.js`, the path-string branch renders
`<div class="w-[320px] max-w-full aspect-[1200/630] bg-fg shrink-0">` with
`mask`/`WebkitMask: url(...) center/contain no-repeat` — the same box geometry commit 84d2f19 set. Measured at **320x168** before and after, so only the artwork changed.

## Test Plan — before/after control

Both states were built from this branch (control = the same tree with the one setting stashed) and probed on a static server at 1440 and 1600 viewports, viewport-sized captures only.

### DOM assertions

| assertion | before (control) | after |
|---|---|---|
| hero box element | `<svg data-auto-logo="doc">` | `<div>` |
| `data-auto-logo` in hero | 1 | **0** |
| computed `mask-image` / `-webkit-mask-image` | `none` | `url(.../img/logo.svg)` |
| `/img/logo.svg` response | n/a | **200**, 54093 bytes, is SVG |
| box rect | 320x168 | 320x168 |

Identical on `/` and `/ja/`, at both viewports.

### Screenshot control

| check | result |
|---|---|
| same build captured twice | **byte-identical** — capture is deterministic, so the diff below is real |
| before vs after @1440 | 23657 / 1296000 px differ, max channel delta 226 |
| before vs after @1600 | 23661 / 1440000 px differ, max channel delta 226 |
| diff bounding box | exactly **320x168** — the logo box and nothing else on the page |

The before/after pair differs in both the DOM assertion and the pixels, so the instrument demonstrably discriminates the two branches.

### Instrument controls (proving the checks aren't blind)

- **tsc discriminates**: adding a bogus sibling key fails with `TS2353: 'logoQqZzBogus' does not exist in type 'ZudoDocConfig'`, so `logo` passing means it is a genuinely known property rather than object-literal checking being off.
- **First probe was blind and was fixed**: it reported `heroBoxes=0` on a page that visibly had an AutoLogo, because `el.className` is an `SVGAnimatedString` on `<svg>` and a `typeof === "string"` filter silently dropped that branch. Switched to `getAttribute("class")`.
- **AutoLogo assertion is hero-scoped**, not page-wide — the page legitimately contains other inline SVGs (header icons, theme toggle), so a page-wide SVG count would prove nothing.

### Gates

`pnpm b4push` — all 9 checks pass, including `check:template-drift` (the favicon allowlist is intact).

## Known, pre-existing, not addressed here

The banner's "W" is a `<text>` element requesting `BodoniSvtyTwoOSITCTT-Book, "Bodoni 72 Oldstyle"` (a macOS font). Consumed as a CSS mask image, the SVG cannot load external fonts, so on Linux the W falls back to a generic serif. This is a property of the asset, not a regression from this change, and the SVG was deliberately not edited.